### PR TITLE
Add browsers password databases

### DIFF
--- a/SnaffCore/Config/DefaultRules/FileContentRules.cs
+++ b/SnaffCore/Config/DefaultRules/FileContentRules.cs
@@ -421,7 +421,7 @@ namespace SnaffCore.Config
                 Description = "Files with these extensions will be searched for Firefox/Thunderbird backups related strings.",
                 RuleName = "browerContentByName",
                 EnumerationScope = EnumerationScope.FileEnumeration,
-                MatchLocation = MatchLoc.FileExtension,
+                MatchLocation = MatchLoc.FileName,
                 WordListType = MatchListType.Exact,
                 MatchAction = MatchAction.Relay,
                 RelayTarget = "KeepFFRegexRed",

--- a/SnaffCore/Config/DefaultRules/FileContentRules.cs
+++ b/SnaffCore/Config/DefaultRules/FileContentRules.cs
@@ -415,6 +415,36 @@ namespace SnaffCore.Config
                     "(\\s|\\\'|\\\"|\\^|=)(A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}(\\s|\\\'|\\\"|$)", // aws access key
                 }
             });
+            // Firefox/Thunderbird backups
+            this.ClassifierRules.Add(new ClassifierRule()
+            {
+                Description = "Files with these extensions will be searched for Firefox/Thunderbird backups related strings.",
+                RuleName = "browerContentByName",
+                EnumerationScope = EnumerationScope.FileEnumeration,
+                MatchLocation = MatchLoc.FileExtension,
+                WordListType = MatchListType.Exact,
+                MatchAction = MatchAction.Relay,
+                RelayTarget = "KeepFFRegexRed",
+                WordList = new List<string>()
+                {
+                    // Firefox/Thunderbird
+                    "logins.json"
+                },
+            });
+            this.ClassifierRules.Add(new ClassifierRule()
+            {
+                Description = "Files with contents matching these regexes are very interesting.",
+                RuleName = "KeepFFRegexRed",
+                EnumerationScope = EnumerationScope.ContentsEnumeration,
+                MatchLocation = MatchLoc.FileContentAsString,
+                WordListType = MatchListType.Regex,
+                MatchAction = MatchAction.Snaffle,
+                Triage = Triage.Red,
+                WordList = new List<string>()
+                {
+                    "\"encryptedPassword\":\"[A-Za-z0-9+/=]+\""
+                }
+            });
 
             // vbscript etc
             /*

--- a/SnaffCore/Config/DefaultRules/FileNameRules.cs
+++ b/SnaffCore/Config/DefaultRules/FileNameRules.cs
@@ -57,6 +57,9 @@ namespace SnaffCore.Config
                         "id_dsa", // test file created
                         "id_ecdsa", // test file created
                         "id_ed25519", // test file created
+                        "key3.db", // Firefox/Thunderbird password database
+                        "key4.db", // Firefox/Thunderbird password database
+                        "Login Data", // Chrome password database
                         "NTDS.DIT", // test file created
                         "shadow", // test file created
                         "pwd.db", // test file created

--- a/SnaffCore/Config/DefaultRules/FileNameRules.cs
+++ b/SnaffCore/Config/DefaultRules/FileNameRules.cs
@@ -57,9 +57,6 @@ namespace SnaffCore.Config
                         "id_dsa", // test file created
                         "id_ecdsa", // test file created
                         "id_ed25519", // test file created
-                        "key3.db", // Firefox/Thunderbird password database
-                        "key4.db", // Firefox/Thunderbird password database
-                        "Login Data", // Chrome password database
                         "NTDS.DIT", // test file created
                         "shadow", // test file created
                         "pwd.db", // test file created
@@ -226,6 +223,9 @@ namespace SnaffCore.Config
                         ".bashrc", // test file created
                         ".profile", // test file created
                         ".zshrc", // test file created
+                        "key3.db", // Firefox/Thunderbird password database
+                        "key4.db", // Firefox/Thunderbird password database
+                        "Login Data", // Chrome password database
                     },
                 }
                 );


### PR DESCRIPTION
Add browers databases
* Firefox: `key3.db`, `key4.db` (depending on FF version)
* Chrome: `Login Data` file

These files are usually located in %APPDATA% or %LOCALAPPDATA% so it makes sense to look for them in shares (user profile backup for example)

Also looks for `logins.json` containing EncryptedPassword attribute with non-empty value.