### PR TITLE
Bugfix: Match on file extensions

### DIFF
--- a/SnaffCore/Config/DefaultRules/FileContentRules.cs
+++ b/SnaffCore/Config/DefaultRules/FileContentRules.cs
@@ -20,7 +20,7 @@ namespace SnaffCore.Config
                 WordList = new List<string>()
                 {
                     // python
-                    "\\.py"
+                    ".py"
                 },
             });
 
@@ -65,12 +65,12 @@ namespace SnaffCore.Config
                 WordList = new List<string>()
                 {
                     // php
-                    "\\.php",
-                    "\\.phtml",
-                    "\\.inc",
-                    "\\.php3",
-                    "\\.php5",
-                    "\\.php7"
+                    ".php",
+                    ".phtml",
+                    ".inc",
+                    ".php3",
+                    ".php5",
+                    ".php7"
                 },
             });
             this.ClassifierRules.Add(new ClassifierRule()
@@ -117,13 +117,13 @@ namespace SnaffCore.Config
                 WordList = new List<string>()
                 {
                     // asp.net
-                    "\\.aspx",
-                    "\\.ashx",
-                    "\\.asmx",
-                    "\\.asp",
-                    "\\.cshtml",
-                    "\\.cs",
-                    "\\.ascx"
+                    ".aspx",
+                    ".ashx",
+                    ".asmx",
+                    ".asp",
+                    ".cshtml",
+                    ".cs",
+                    ".ascx"
                 },
             });
             this.ClassifierRules.Add(new ClassifierRule()
@@ -167,11 +167,11 @@ namespace SnaffCore.Config
                 WordList = new List<string>()
                 {
                     // java
-                    "\\.jsp",
-                    "\\.do",
-                    "\\.java",
+                    ".jsp",
+                    ".do",
+                    ".java",
                     // coldfusion
-                    "\\.cfm",
+                    ".cfm",
                 },
             });
             this.ClassifierRules.Add(new ClassifierRule()
@@ -214,7 +214,7 @@ namespace SnaffCore.Config
                 WordList = new List<string>()
                 {
                     // ruby
-                    "\\.rb"
+                    ".rb"
                 },
             });
             this.ClassifierRules.Add(new ClassifierRule()
@@ -258,7 +258,7 @@ namespace SnaffCore.Config
                 WordList = new List<string>()
                 {
                     // perl
-                    "\\.pl"
+                    ".pl"
                 },
             });
             this.ClassifierRules.Add(new ClassifierRule()
@@ -302,9 +302,9 @@ namespace SnaffCore.Config
                 WordList = new List<string>()
                 {
                     // powershell
-                    "\\.psd1",
-                    "\\.psm1",
-                    "\\.ps1",
+                    ".psd1",
+                    ".psm1",
+                    ".ps1",
                 },
             });
             this.ClassifierRules.Add(new ClassifierRule()
@@ -345,8 +345,8 @@ namespace SnaffCore.Config
                 WordList = new List<string>()
                 {
                     // cmd.exe
-                    "\\.bat",
-                    "\\.cmd"
+                    ".bat",
+                    ".cmd"
                 },
             });
             this.ClassifierRules.Add(new ClassifierRule()
@@ -385,9 +385,9 @@ namespace SnaffCore.Config
                 WordList = new List<string>()
                 {
                     // bash, sh, zsh, etc
-                    "\\.sh",
-                    "\\.rc",
-                    "\\.profile"
+                    ".sh",
+                    ".rc",
+                    ".profile"
                 },
             });
             this.ClassifierRules.Add(new ClassifierRule()
@@ -430,7 +430,7 @@ namespace SnaffCore.Config
                 WordList = new List<string>()
                 {
                     // Firefox/Thunderbird
-                    "logins\\.json"
+                    "logins.json"
                 },
             });
             this.ClassifierRules.Add(new ClassifierRule()
@@ -492,25 +492,25 @@ namespace SnaffCore.Config
                 RelayTarget = "KeepConfigRegexRed",
                 WordList = new List<string>()
                 {
-                    "\\.yaml",
-                    "\\.yml",
-                    "\\.toml",
-                    "\\.xml",
-                    "\\.json",
-                    "\\.config",
-                    "\\.ini",
-                    "\\.inf",
-                    "\\.cnf",
-                    "\\.conf",
-                    "\\.properties",
-                    "\\.env",
-                    "\\.dist",
-                    "\\.txt",
-                    "\\.sql",
-                    "\\.log",
-                    "\\.sqlite",
-                    "\\.sqlite3",
-                    "\\.fdb"
+                    ".yaml",
+                    ".yml",
+                    ".toml",
+                    ".xml",
+                    ".json",
+                    ".config",
+                    ".ini",
+                    ".inf",
+                    ".cnf",
+                    ".conf",
+                    ".properties",
+                    ".env",
+                    ".dist",
+                    ".txt",
+                    ".sql",
+                    ".log",
+                    ".sqlite",
+                    ".sqlite3",
+                    ".fdb"
                 },
             });
 
@@ -560,7 +560,7 @@ namespace SnaffCore.Config
                     "_dsa", // test file created
                     "_ed25519", // test file created
                     "_ecdsa", // test file created
-                    "\\.pem",
+                    ".pem",
                 },
             });
 
@@ -591,11 +591,11 @@ namespace SnaffCore.Config
                     Triage = Triage.Red,
                     WordList = new List<string>()
                     {
-                        "\\.der",   // test file created
-                        "\\.pfx",
-                        "\\.pk12",
-                        "\\.p12",
-                        "\\.pkcs12",
+                        ".der",   // test file created
+                        ".pfx",
+                        ".pk12",
+                        ".p12",
+                        ".pkcs12",
                     },
                 }
             );

--- a/SnaffCore/Config/DefaultRules/FileDiscardRules.cs
+++ b/SnaffCore/Config/DefaultRules/FileDiscardRules.cs
@@ -20,30 +20,30 @@ namespace SnaffCore.Config
                     {
                         // always skip these file extensions
                         // image formats
-                        "\\.bmp", // test file created
-                        "\\.eps", // test file created
-                        "\\.gif", // test file created
-                        "\\.ico", // test file created
-                        "\\.jfi", // test file created
-                        "\\.jfif", // test file created
-                        "\\.jif", // test file created
-                        "\\.jpe", // test file created
-                        "\\.jpeg", // test file created
-                        "\\.jpg", // test file created
-                        "\\.png", // test file created
-                        "\\.psd", // test file created
-                        "\\.svg", // test file created
-                        "\\.tif", // test file created
-                        "\\.tiff", // test file created
-                        "\\.webp", // test file created
-                        "\\.xcf", // test file created
+                        ".bmp", // test file created
+                        ".eps", // test file created
+                        ".gif", // test file created
+                        ".ico", // test file created
+                        ".jfi", // test file created
+                        ".jfif", // test file created
+                        ".jif", // test file created
+                        ".jpe", // test file created
+                        ".jpeg", // test file created
+                        ".jpg", // test file created
+                        ".png", // test file created
+                        ".psd", // test file created
+                        ".svg", // test file created
+                        ".tif", // test file created
+                        ".tiff", // test file created
+                        ".webp", // test file created
+                        ".xcf", // test file created
                         // font 
-                        "\\.ttf", // test file created
-                        "\\.otf", // test file created
+                        ".ttf", // test file created
+                        ".otf", // test file created
                         // misc
-                        "\\.lock", // test file created
-                        "\\.css", // test file created
-                        "\\.less" // test file created
+                        ".lock", // test file created
+                        ".css", // test file created
+                        ".less" // test file created
                     },
                 });
         }

--- a/SnaffCore/Config/DefaultRules/FileNameRules.cs
+++ b/SnaffCore/Config/DefaultRules/FileNameRules.cs
@@ -20,31 +20,31 @@ namespace SnaffCore.Config
                     WordList = new List<string>()
                     {
                         // keepass databases
-                        "\\.kdbx", // test file created
-                        "\\.kdb", // test file created
+                        ".kdbx", // test file created
+                        ".kdb", // test file created
                         // putty private keys
-                        "\\.ppk", // test file created
+                        ".ppk", // test file created
                         // virtual disks
-                        "\\.vmdk", // test file created
-                        "\\.vhd", // test file created
-                        "\\.vhdx", // test file created
+                        ".vmdk", // test file created
+                        ".vhd", // test file created
+                        ".vhdx", // test file created
                         // password safe
-                        "\\.psafe3", // test file created
+                        ".psafe3", // test file created
                         // cloud service config
-                        "\\.cscfg", // test file created
+                        ".cscfg", // test file created
                         // kde wallet manager
-                        "\\.kwallet", // test file created
+                        ".kwallet", // test file created
                         // vpn profiles
-                        "\\.tblk", // test file created
-                        "\\.ovpn", // test file created
+                        ".tblk", // test file created
+                        ".ovpn", // test file created
                         // full disk backups
-                        "\\.bkf",
-                        "\\.v2i",
-                        "\\.gho",
-                        "\\.vbk",
-                        "\\.tib",
-                        "\\.tibx",
-                        "\\.mtf"
+                        ".bkf",
+                        ".v2i",
+                        ".gho",
+                        ".vbk",
+                        ".tib",
+                        ".tibx",
+                        ".mtf"
                     },
                 });
 
@@ -65,18 +65,18 @@ namespace SnaffCore.Config
                         "id_dsa", // test file created
                         "id_ecdsa", // test file created
                         "id_ed25519", // test file created
-                        "NTDS\\.DIT", // test file created
+                        "NTDS.DIT", // test file created
                         "shadow", // test file created
-                        "pwd\\.db", // test file created
+                        "pwd.db", // test file created
                         "passwd", // test file created
-                        "running-config\\.cfg", // test file created
-                        "startup-config\\.cfg", // test file created
+                        "running-config.cfg", // test file created
+                        "startup-config.cfg", // test file created
                         "running-config", // test file created
                         "startup-config", // test file created
-                        "MEMORY\\.DMP",
-                        "hiberfil\\.sys",
-                        "lsass\\.dmp",
-                        "lsass\\.exe\\.dmp"
+                        "MEMORY.DMP",
+                        "hiberfil.sys",
+                        "lsass.dmp",
+                        "lsass.exe.dmp"
                     },
                 }
                 );
@@ -93,13 +93,13 @@ namespace SnaffCore.Config
                     Triage = Triage.Black,
                     WordList = new List<string>()
                 {
-                        "\\.ssh\\\\", // test file created
-                        "\\.purple\\\\accounts.xml", // test file created
-                        "\\.aws\\\\", // test file created
-                        "\\.gem\\\\credentials", // test file created
-                        "doctl\\\\config.yaml", // test file created
-                        "config\\\\hub",  // test file created
-                        "control\\customsettings\\.ini"
+                        ".ssh\\", // test file created
+                        ".purple\\accounts.xml", // test file created
+                        ".aws\\", // test file created
+                        ".gem\\credentials", // test file created
+                        "doctl\\config.yaml", // test file created
+                        "config\\hub",  // test file created
+                        "control\\customsettings.ini"
                 },
                 }
             );
@@ -117,34 +117,34 @@ namespace SnaffCore.Config
                     Triage = Triage.Red,
                     WordList = new List<string>()
                     {
-                        "\\.jks", // test file created
+                        ".jks", // test file created
                         // rdp
-                        "\\.rdp", // test file created
-                        "\\.rdg", // test file created
+                        ".rdp", // test file created
+                        ".rdg", // test file created
                         // bitlocker recovery keys
-                        "\\.bek", // test file created
+                        ".bek", // test file created
                         // tpm backups
-                        "\\.tpm", // test file created
-                        "\\.fve", // test file created
+                        ".tpm", // test file created
+                        ".fve", // test file created
                         // packet capture
-                        "\\.pcap", // test file created
-                        "\\.cap", // test file created
+                        ".pcap", // test file created
+                        ".cap", // test file created
                         // misc key material
-                        "\\.key", // test file created
-                        "\\.keypair", // test file created
-                        "\\.keychain", // test file created
+                        ".key", // test file created
+                        ".keypair", // test file created
+                        ".keychain", // test file created
                         // disk image
-                        "\\.wim", // test file created
+                        ".wim", // test file created
                         // virtual machines
-                        "\\.ova", // test file created
-                        "\\.ovf", // test file created
+                        ".ova", // test file created
+                        ".ovf", // test file created
                         // db backups
-                        "\\.mdf", // test file created
-                        "\\.sdf", // test file created
-                        "\\.sqldump", // test file created
-                        "\\.bak",
+                        ".mdf", // test file created
+                        ".sdf", // test file created
+                        ".sqldump", // test file created
+                        ".bak",
                         // mem dumps
-                        "\\.dmp"
+                        ".dmp"
                      },
                 }
                 );
@@ -162,80 +162,80 @@ namespace SnaffCore.Config
                     Triage = Triage.Red,
                     WordList = new List<string>()
                     {
-                        "passwords\\.txt",
-                        "pass\\.txt",
-                        "accounts\\.txt",
-                        "passwords\\.doc",
-                        "pass\\.doc",
-                        "accounts\\.doc",
-                        "passwords\\.xls",
-                        "pass\\.xls",
-                        "accounts\\.xls",
-                        "passwords\\.docx",
-                        "pass\\.docx",
-                        "accounts\\.docx",
-                        "passwords\\.xlsx",
-                        "pass\\.xlsx",
-                        "accounts\\.xlsx",
-                        "confCons\\.xml",
-                        "SqlStudio\\.bin",
-                        "secrets\\.txt",
-                        "secrets\\.doc",
-                        "secrets\\.xls",
-                        "secrets\\.docx",
-                        "secrets\\.xlsx",
-                        "unattend\\.xml", // test file created
-                        "\\.netrc", // test file created
+                        "passwords.txt",
+                        "pass.txt",
+                        "accounts.txt",
+                        "passwords.doc",
+                        "pass.doc",
+                        "accounts.doc",
+                        "passwords.xls",
+                        "pass.xls",
+                        "accounts.xls",
+                        "passwords.docx",
+                        "pass.docx",
+                        "accounts.docx",
+                        "passwords.xlsx",
+                        "pass.xlsx",
+                        "accounts.xlsx",
+                        "confCons.xml",
+                        "SqlStudio.bin",
+                        "secrets.txt",
+                        "secrets.doc",
+                        "secrets.xls",
+                        "secrets.docx",
+                        "secrets.xlsx",
+                        "unattend.xml", // test file created
+                        ".netrc", // test file created
                         "_netrc", // test file created
-                        "\\.htpasswd", // test file created
-                        "otr\\.private_key", // test file created
-                        "\\.secret_token\\.rb", // test file created
-                        "carrierwave\\.rb", // test file created
-                        "database\\.yml", // test file created
-                        "omniauth\\.rb", // test file created
-                        "settings\\.py", // test file created
-                        "\\.agilekeychain", // test file created
-                        "\\.keychain", // test file created
-                        "jenkins\\.plugins\\.publish_over_ssh\\.BapSshPublisherPlugin\\.xml", // test file created
-                        "credentials\\.xml", // test file created
-                        "LocalSettings\\.php", // test file created
-                        "Favorites\\.plist", // test file created
-                        "knife\\.rb", // test file created
-                        "proxy\\.config", // test file created
+                        ".htpasswd", // test file created
+                        "otr.private_key", // test file created
+                        ".secret_token.rb", // test file created
+                        "carrierwave.rb", // test file created
+                        "database.yml", // test file created
+                        "omniauth.rb", // test file created
+                        "settings.py", // test file created
+                        ".agilekeychain", // test file created
+                        ".keychain", // test file created
+                        "jenkins.plugins.publish_over_ssh.BapSshPublisherPlugin.xml", // test file created
+                        "credentials.xml", // test file created
+                        "LocalSettings.php", // test file created
+                        "Favorites.plist", // test file created
+                        "knife.rb", // test file created
+                        "proxy.config", // test file created
                         "proftpdpasswd", // test file created
-                        "robomongo\\.json", // test file created
-                        "filezilla\\.xml", // test file created
-                        "recentservers\\.xml", // test file created
-                        "terraform\\.tfvars", // test file created
-                        "\\.exports", // test file created
-                        "\\.functions", // test file created
-                        "\\.extra", // test file created
-                        "\\.bash_history", // test file created
-                        "\\.zsh_history", // test file created
-                        "\\.sh_history", // test file created
+                        "robomongo.json", // test file created
+                        "filezilla.xml", // test file created
+                        "recentservers.xml", // test file created
+                        "terraform.tfvars", // test file created
+                        ".exports", // test file created
+                        ".functions", // test file created
+                        ".extra", // test file created
+                        ".bash_history", // test file created
+                        ".zsh_history", // test file created
+                        ".sh_history", // test file created
                         "zhistory", // test file created
-                        "\\.mysql_history", // test file created
-                        "\\.psql_history", // test file created
-                        "\\.pgpass", // test file created
-                        "\\.irb_history", // test file created
-                        "\\.dbeaver-data-sources\\.xml", // test file created
-                        "\\.s3vfg", // test file created
-                        "sftp-config\\.json", // test file created
-                        "config\\.inc", // test file created
-                        "config\\.php", // test file created
+                        ".mysql_history", // test file created
+                        ".psql_history", // test file created
+                        ".pgpass", // test file created
+                        ".irb_history", // test file created
+                        ".dbeaver-data-sources.xml", // test file created
+                        ".s3vfg", // test file created
+                        "sftp-config.json", // test file created
+                        "config.inc", // test file created
+                        "config.php", // test file created
                         "keystore", // test file created
                         "keyring", // test file created
-                        "\\.tugboat", // test file created
-                        "\\.git-credentials", // test file created
-                        "\\.gitconfig", // test file created
-                        "\\.dockercfg", // test file created
-                        "\\.npmrc", // test file created
-                        "\\.env", // test file created
-                        "\\.bashrc", // test file created
-                        "\\.profile", // test file created
-                        "\\.zshrc", // test file created
-                        "key3\\.db", // Firefox/Thunderbird password database
-                        "key4\\.db", // Firefox/Thunderbird password database
+                        ".tugboat", // test file created
+                        ".git-credentials", // test file created
+                        ".gitconfig", // test file created
+                        ".dockercfg", // test file created
+                        ".npmrc", // test file created
+                        ".env", // test file created
+                        ".bashrc", // test file created
+                        ".profile", // test file created
+                        ".zshrc", // test file created
+                        "key3.db", // Firefox/Thunderbird password database
+                        "key4.db", // Firefox/Thunderbird password database
                         "Login Data", // Chrome password database
                     },
                 }


### PR DESCRIPTION
I noticed that my snaffler run did not detect any filename matches, despite some existing in the shares.

Root-cause-wise, I believe adding the escaping of the `.` and `\\` characters in commit a23c2c3f000243c2be800c25ab7b3ee4c7dd2fd7 was erroneous - the matches are marked as `Contains`, `EndsWith`, `StartsWith` and `Exact` (not `Regex`), so are escaped prior to matching; this resulted in trying to match an actual backslash at the start of the file extension, which always failed.

To reproduce the issue, contents of folder:

```
- password.txt
- test.ppk
```

Running snaffler on that directory, prior to this fix:

```
[PC\user@PC] 2021-05-24 17:17:28Z [Info] Parsing args...
[PC\user@PC] 2021-05-24 17:17:28Z [Info] Parsed args successfully.
[PC\user@PC] 2021-05-24 17:17:28Z [Info] Creating a TreeWalker task for C:\Users\user\Documents\directory
[PC\user@PC] 2021-05-24 17:17:28Z [Info] Created all TreeWalker tasks.
[PC\user@PC] 2021-05-24 17:17:28Z [File] {Green}<KeepNameContainsGreen|RW|passw|0B|2021-05-24 06:32:27Z>(C:\Users\user\Documents\directory\password.txt) password.txt
```

After this commit:

```
[PC\user@PC] 2021-05-24 17:43:39Z [Info] Parsing args...
[PC\user@PC] 2021-05-24 17:43:39Z [Info] Parsed args successfully.
[PC\user@PC] 2021-05-24 17:43:39Z [Info] Creating a TreeWalker task for C:\Users\user\Documents\directory
[PC\user@PC] 2021-05-24 17:43:39Z [Info] Created all TreeWalker tasks.
[PC\user@PC] 2021-05-24 17:43:39Z [File] {Green}<KeepNameContainsGreen|RW|passw|0B|2021-05-24 06:32:27Z>(C:\Users\user\Documents\directory\password.txt) password.txt
[PC\user@PC] 2021-05-24 17:43:39Z [File] {Black}<KeepExtExactBlack|RW|^\.ppk$|0B|2021-05-24 06:31:24Z>(C:\Users\user\Documents\directory\test.ppk) .ppk
```