### PR TITLE
Enable reporting of inaccessible shares

### DIFF
--- a/SnaffCore/Classifiers/ClassifierRule.cs
+++ b/SnaffCore/Classifiers/ClassifierRule.cs
@@ -72,6 +72,7 @@ namespace Classifiers
         Black,
         Green,
         Yellow,
-        Red
+        Red,
+        Gray   //HCK_PR strictly informational - it exists but could not be snaffled
     }
 }

--- a/SnaffCore/Classifiers/ShareClassifier.cs
+++ b/SnaffCore/Classifiers/ShareClassifier.cs
@@ -29,8 +29,7 @@ namespace Classifiers
                     case MatchAction.Discard:
                         return true;
                     case MatchAction.Snaffle:
-                        // in this context snaffle means 'send a report up the queue but don't scan the share'
-                        if (IsShareReadable(share))
+                        if (IsShareReadable(share) )
                         {
                             ShareResult shareResult = new ShareResult()
                             {
@@ -76,6 +75,6 @@ namespace Classifiers
         public string SharePath { get; set; }
         public string ShareComment { get; set; }
         public bool Listable { get; set; }
-        public Triage Triage { get; set; } = Triage.Green;
+        public Triage Triage { get; set; } = Triage.Gray;   //HCK_PR  new default value
     }
 }

--- a/SnaffCore/Config/Options.cs
+++ b/SnaffCore/Config/Options.cs
@@ -34,6 +34,7 @@ namespace SnaffCore.Config
         public bool ShareFinderEnabled { get; set; } = true;
         public string TargetDomain { get; set; }
         public string TargetDc { get; set; }
+        public bool LogDeniedShares { get; set; } = false;   //HCK_PR  New config option 
 
         // FileScanner Options
         public bool DomainUserRules { get; set; } = false;

--- a/Snaffler/SnaffleRunner.cs
+++ b/Snaffler/SnaffleRunner.cs
@@ -194,7 +194,8 @@ namespace Snaffler
         private void ProcessMessage(SnafflerMessage message)
         {
             //  standardized time formatting
-            string datetime =  String.Format("{1}{0}{2:u}{0}",  Options.Separator,hostString(), message.DateTime);
+            //HCK_PR  UTC timestamp 
+            string datetime =  String.Format("{1}{0}{2:u}{0}",  Options.Separator,hostString(), message.DateTime.ToUniversalTime());
 
             switch (message.Type)
             {


### PR DESCRIPTION
Wanted to log all shares discovered, even if not accessible.
* For red team:  you may not have access to the share (yet), but don't you want to know it's there?
* For blue team,  allows you to see some always-on shares reported for the host, even if no other items are snaffled.  Gives you confidence that the scan actually ran against the server