### PR TITLE
Fix regex

### DIFF
--- a/SnaffCore/Config/DefaultRules/FileNameRules.cs
+++ b/SnaffCore/Config/DefaultRules/FileNameRules.cs
@@ -99,10 +99,10 @@ namespace SnaffCore.Config
                     Triage = Triage.Black,
                     WordList = new List<string>()
                 {
-                        "\\\\.ssh\\\\", // test file created
-                        "\\\\.purple\\\\accounts.xml", // test file created
-                        "\\\\.aws\\\\", // test file created
-                        "\\\\.gem\\\\credentials", // test file created
+                        "\\\\\\.ssh\\\\", // test file created
+                        "\\\\\\.purple\\\\accounts.xml", // test file created
+                        "\\\\\\.aws\\\\", // test file created
+                        "\\\\\\.gem\\\\credentials", // test file created
                         "doctl\\\\config.yaml", // test file created
                         "config\\\\hub",  // test file created
                         "control\\\\customsettings.ini"


### PR DESCRIPTION
Escape the `.` (dot) char in regex (because **Contains** will use regexes https://github.com/SnaffCon/Snaffler/blob/a75b28080eb4cfb3162dab16883493973062107e/SnaffCore/Config/ClassifierOptions.cs#L39)