### PR TITLE
DFS v1 path discovery

### DIFF
--- a/SnaffCore/Config/Options.cs
+++ b/SnaffCore/Config/Options.cs
@@ -18,7 +18,6 @@ namespace SnaffCore.Config
         public int InterestLevel { get; set; } = 0;
         public bool DfsOnly { get; set; } = false;
         public bool DfsShareDiscovery { get; set; } = false;
-//        public List<DFSShare> DfsShares { get; set; } = new List<DFSShare>();
         public Dictionary<string, string> DfsSharesDict { get; set; } = new Dictionary<string, string>();
         public List<string> DfsNamespacePaths { get; set; } = new List<string>();
         public string CurrentUser { get; set; } = WindowsIdentity.GetCurrent().Name;

--- a/SnaffCore/Config/Options.cs
+++ b/SnaffCore/Config/Options.cs
@@ -17,7 +17,9 @@ namespace SnaffCore.Config
         public bool ScanFoundShares { get; set; } = true;
         public int InterestLevel { get; set; } = 0;
         public bool DfsOnly { get; set; } = false;
-        public List<DFSShare> DfsShares { get; set; } = new List<DFSShare>();
+        public bool DfsShareDiscovery { get; set; } = false;
+//        public List<DFSShare> DfsShares { get; set; } = new List<DFSShare>();
+        public Dictionary<string, string> DfsSharesDict { get; set; } = new Dictionary<string, string>();
         public List<string> DfsNamespacePaths { get; set; } = new List<string>();
         public string CurrentUser { get; set; } = WindowsIdentity.GetCurrent().Name;
 

--- a/SnaffCore/SnaffCon.cs
+++ b/SnaffCore/SnaffCon.cs
@@ -103,6 +103,11 @@ namespace SnaffCore
 
             if (MyOptions.PathTargets == null && MyOptions.ComputerTargets == null)
             {
+                if(MyOptions.DfsSharesDict == null)
+                {
+                    Mq.Info("Invoking DFS Discovery because ComputerTargets and PathTargets were being discovered");
+                    DomainDfsDiscovery();
+                }
                 DomainTargetDiscovery();
             }
             // if we've been told what computers to hit...


### PR DESCRIPTION
- Changed discovery routine for v1 namespaces.

- Added `DfsShareDiscovery = true` config file option to allow DFS discovery even when `ComputerTargets` is set.  This allows "deduplication" of results.