### PR TITLE
added back FolderTarget mode and improved username regex

### DIFF
--- a/SnaffCore/ActiveDirectory/DfsFinder.cs
+++ b/SnaffCore/ActiveDirectory/DfsFinder.cs
@@ -130,7 +130,7 @@ namespace SnaffCore.ActiveDirectory
                                     if (Target.Contains(@"\"))
                                     {
                                         var DFSroot = Target.Split('\\')[3];
-                                        string ShareName = resEnt.GetProperty(@"msdfs-linkpathv2");
+                                        string ShareName = resEnt.GetProperty(@"msdfs-linkpathv2").Replace("/","\\");
                                         DFSShares.Add(new DFSShare { Name = $@"{DFSroot}{ShareName}", RemoteServerName = Target.Split('\\')[2], DFSNamespace = dfsnamespace });
                                     }
                                 }

--- a/SnaffCore/Config/Options.cs
+++ b/SnaffCore/Config/Options.cs
@@ -47,6 +47,7 @@ namespace SnaffCore.Config
 
         // FileScanner Options
         public bool DomainUserRules { get; set; } = false;
+        public int DomainUserMinLen { get; set; } = 6;
         public DomainUserNamesFormat[] DomainUserNameFormats { get; set; } = new DomainUserNamesFormat[] { DomainUserNamesFormat.sAMAccountName };
 
         // passwords to try on certs that require one

--- a/SnaffCore/Config/Options.cs
+++ b/SnaffCore/Config/Options.cs
@@ -9,7 +9,7 @@ namespace SnaffCore.Config
         public static Options MyOptions { get; set; }
 
         // Manual Targeting Options
-        public string[] PathTargets { get; set; }
+        public List<string> PathTargets { get; set; } = new List<string>();
         public string[] ComputerTargets { get; set; }
         public string ComputerTargetsLdapFilter { get; set; } = "(objectClass=computer)";
         public bool ScanSysvol { get; set; } = true;

--- a/SnaffCore/SnaffCon.cs
+++ b/SnaffCore/SnaffCon.cs
@@ -97,32 +97,42 @@ namespace SnaffCore
             }
 
             // Explicit folder setting overrides DFS
-            if (MyOptions.PathTargets == null && (MyOptions.DfsShareDiscovery || MyOptions.DfsOnly))
+            if (MyOptions.PathTargets.Count != 0 && (MyOptions.DfsShareDiscovery || MyOptions.DfsOnly))
             {
                 DomainDfsDiscovery();
             }
 
-            if (MyOptions.PathTargets == null && MyOptions.ComputerTargets == null)
+            if (MyOptions.PathTargets.Count == 0 && MyOptions.ComputerTargets == null)
             {
-                if (MyOptions.DfsSharesDict == null)
+                if (MyOptions.DfsSharesDict.Count == 0)
                 {
                     Mq.Info("Invoking DFS Discovery because no ComputerTargets or PathTargets were specified");
                     DomainDfsDiscovery();
                 }
+
                 if (!MyOptions.DfsOnly)
                 {
-                    Mq.Info("Invoking full domain computer discovery.";
+                    Mq.Info("Invoking full domain computer discovery.");
                     DomainTargetDiscovery();
                 }
                 else
                 {
-                    Mq.Info("Skipping domain computer discovery."
+                    Mq.Info("Skipping domain computer discovery.");
+                    foreach (string share in MyOptions.DfsSharesDict.Keys)
+                    {
+                        if (!MyOptions.PathTargets.Contains(share))
+                        {
+                            MyOptions.PathTargets.Add(share);
+                        }
+                    }
+                    Mq.Info("Starting TreeWalker tasks on DFS shares.");
+                    FileDiscovery(MyOptions.PathTargets.ToArray());
                 }
             }
             // otherwise we should have a set of path targets...
-            else if (MyOptions.PathTargets != null)
+            else if (MyOptions.PathTargets.Count != 0)
             {
-                FileDiscovery(MyOptions.PathTargets);
+                FileDiscovery(MyOptions.PathTargets.ToArray());
             }
             // or we've been told what computers to hit...
             else if (MyOptions.ComputerTargets != null)

--- a/SnaffCore/SnaffCon.cs
+++ b/SnaffCore/SnaffCon.cs
@@ -253,6 +253,12 @@ namespace SnaffCore
 
                         foreach (string user in MyOptions.DomainUsersToMatch)
                         {
+                            if (user.Length < MyOptions.DomainUserMinLen)
+                            {
+                                Mq.Trace(String.Format("Skipping regex for \"{0}\".  Shorter than minimum chars: {1}", user, MyOptions.DomainUserMinLen));
+                                continue;
+                            }
+
                             // Use the null character to match begin and end of line
                             string pattern = "(| |'|\")" + Regex.Escape(user) + "(| |'|\")";
                             Regex regex = new Regex(pattern,

--- a/SnaffCore/SnaffCon.cs
+++ b/SnaffCore/SnaffCon.cs
@@ -96,7 +96,8 @@ namespace SnaffCore
                 DomainUserDiscovery();
             }
 
-            if (MyOptions.DfsShareDiscovery || MyOptions.DfsOnly)
+            // Explicit folder setting overrides DFS
+            if (MyOptions.PathTargets == null && (MyOptions.DfsShareDiscovery || MyOptions.DfsOnly))
             {
                 DomainDfsDiscovery();
             }
@@ -110,7 +111,12 @@ namespace SnaffCore
                 }
                 DomainTargetDiscovery();
             }
-            // if we've been told what computers to hit...
+            // otherwise we should have a set of path targets...
+            else if (MyOptions.PathTargets != null)
+            {
+                FileDiscovery(MyOptions.PathTargets);
+            }
+            // or we've been told what computers to hit...
             else if (MyOptions.ComputerTargets != null)
             {
                 ShareDiscovery(MyOptions.ComputerTargets);
@@ -247,7 +253,8 @@ namespace SnaffCore
 
                         foreach (string user in MyOptions.DomainUsersToMatch)
                         {
-                            string pattern = "( |'|\")" + Regex.Escape(user) + "( |'|\")";
+                            // Use the null character to match begin and end of line
+                            string pattern = "(| |'|\")" + Regex.Escape(user) + "(| |'|\")";
                             Regex regex = new Regex(pattern,
                                 RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.CultureInvariant);
                             configClassifierRule.Regexes.Add(regex);

--- a/Snaffler/Config.cs
+++ b/Snaffler/Config.cs
@@ -197,7 +197,7 @@ namespace Snaffler
                 if (dirTargetArg.Parsed)
                 {
                     parsedConfig.ShareFinderEnabled = false;
-                    parsedConfig.PathTargets = new string[] { dirTargetArg.Value };
+                    parsedConfig.PathTargets.Add(dirTargetArg.Value);
                     Mq.Degub("Disabled finding shares.");
                     Mq.Degub("Target path is " + dirTargetArg.Value);
                 }


### PR DESCRIPTION
- Username matching wasn't working when the name was alone on a line (no spaces or quotes around it).
- I had accidentally de-factored the FolderPath invocation during a previous PR (sorry)
