### PR TITLE
Replace newlines with \n for consistent log lines

### DIFF
--- a/Snaffler/SnaffleRunner.cs
+++ b/Snaffler/SnaffleRunner.cs
@@ -8,6 +8,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 namespace Snaffler
 {
@@ -319,6 +320,7 @@ namespace Snaffler
                 {
                     matchedstring = message.FileResult.TextResult.MatchedStrings[0];
                     matchcontext = message.FileResult.TextResult.MatchContext;
+                    matchcontext = Regex.Replace(matchcontext, @"\r\n?|\n", "\\n"); // Replace newlines with \n for consistent log lines
                 }
 
                 return string.Format(fileResultTemplate, triageString, matchedclassifier, canread, canwrite, canmodify, matchedstring, fileSizeString, modifiedStamp,


### PR DESCRIPTION
This PR changes log lines from this:
![image](https://user-images.githubusercontent.com/73472903/155744148-cfca3803-d21c-4ae1-aa06-25f9f3538295.png)

to this:
![image](https://user-images.githubusercontent.com/73472903/155744223-772cef00-cd85-4980-a964-5d496096b65d.png)

detail shot of `\n` :rofl: 
![image](https://user-images.githubusercontent.com/73472903/155744303-457effc8-025c-44fd-914a-e9aaa774a14c.png)
