### PR TITLE
JSON Output Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The key incantations are:
 
 `-z`   Path to a config file that defines all of the above, and much much more! See below for more details. Give it `-z generate` to generate a sample config file called `.\default.toml`.
 
+`-t` Type of log you would like to output. Currently supported options are plain and JSON. Defaults to plain.
+
 ## What does any of this log output mean?
 
 Hopefully this annotated example will help:

--- a/SnaffCore/Config/Options.cs
+++ b/SnaffCore/Config/Options.cs
@@ -4,6 +4,12 @@ using SnaffCore.ActiveDirectory;
 
 namespace SnaffCore.Config
 {
+    public enum LogType
+    {
+        Plain = 0,
+        JSON = 1
+    }
+
     public partial class Options
     {
         public static Options MyOptions { get; set; }
@@ -36,6 +42,7 @@ namespace SnaffCore.Config
         // Logging Options
         public bool LogToFile { get; set; } = false;
         public string LogFilePath { get; set; }
+        public LogType LogType { get; set; }
         public bool LogTSV { get; set; } = false;
         public char Separator { get; set; } = ' ';
         public bool LogToConsole { get; set; } = true;

--- a/Snaffler/Config.cs
+++ b/Snaffler/Config.cs
@@ -93,7 +93,7 @@ namespace Snaffler
                 "Stops after finding shares, doesn't walk their filesystems.", false);
             ValueArgument<string> compTargetArg = new ValueArgument<string>('n', "comptarget", "Computer (or comma separated list) to target.");
             ValueArgument<string> ruleDirArg = new ValueArgument<string>('p', "rulespath", "Path to a directory full of toml-formatted rules. Snaffler will load all of these in place of the default ruleset.");
-            ValueArgument<string> logType = new ValueArgument<string>('t', "logtype", "Type of log you would like to output. Currently supported options are plain and JSON. Defaults to plain");
+            ValueArgument<string> logType = new ValueArgument<string>('t', "logtype", "Type of log you would like to output. Currently supported options are plain and JSON. Defaults to plain.");
             // list of letters i haven't used yet: egknqw
 
             CommandLineParser.CommandLineParser parser = new CommandLineParser.CommandLineParser();

--- a/Snaffler/Config.cs
+++ b/Snaffler/Config.cs
@@ -93,6 +93,7 @@ namespace Snaffler
                 "Stops after finding shares, doesn't walk their filesystems.", false);
             ValueArgument<string> compTargetArg = new ValueArgument<string>('n', "comptarget", "Computer (or comma separated list) to target.");
             ValueArgument<string> ruleDirArg = new ValueArgument<string>('p', "rulespath", "Path to a directory full of toml-formatted rules. Snaffler will load all of these in place of the default ruleset.");
+            ValueArgument<string> logType = new ValueArgument<string>('t', "logtype", "Type of log you would like to output. Currently supported options are plain and JSON. Defaults to plain");
             // list of letters i haven't used yet: egknqw
 
             CommandLineParser.CommandLineParser parser = new CommandLineParser.CommandLineParser();
@@ -116,6 +117,7 @@ namespace Snaffler
             parser.Arguments.Add(maxThreadsArg);
             parser.Arguments.Add(compTargetArg);
             parser.Arguments.Add(ruleDirArg);
+            parser.Arguments.Add(logType);
 
             // extra check to handle builtin behaviour from cmd line arg parser
             if ((args.Contains("--help") || args.Contains("/?") || args.Contains("help") || args.Contains("-h") || args.Length == 0))
@@ -133,6 +135,21 @@ namespace Snaffler
             try
             {
                 parser.ParseCommandLine(args);
+
+                if (logType.Parsed && !String.IsNullOrWhiteSpace(logType.Value))
+                {
+                    //Set the default to plain
+                    parsedConfig.LogType = LogType.Plain;
+                    //if they set a different type then replace it with the new type.
+                    if (logType.Value.ToLower() == "json")
+                    {
+                        parsedConfig.LogType = LogType.JSON;
+                    }
+                    else
+                    {
+                        Mq.Info("Invalid type argument passed (" + logType.Value + ") defaulting to plaintext");
+                    }
+                }
 
                 if (ruleDirArg.Parsed && !String.IsNullOrWhiteSpace(ruleDirArg.Value))
                 {


### PR DESCRIPTION
Added support for JSON formatted output using NLog's native capabilities. Output is essentially structured like so:
```
{
    "entries": [
        {JSON object representing line that is normally logged},
        ....
    ]
}
```

Items found by Snaffler will have their Object representation in memory automatically serialised into a JSON object up to a certain point which will be included in the logged line. The current recuse depth for this is 5 which seemed to work best at preserving information but not succumbing to circular references.

Since this just gets NLog to optionally write each line out as JSON object there is an additional function that I added that reads over the output file once Snaffler has finished Snaffling to normalise it into one JSON object suitable for other programs to read. This does add some additional overhead in terms of processing but was the easiest and most reasonable solution I could think of that didn't involve changing a lot of things.
