### PR TITLE
Add DBeaver and DBVis credential storage

### DIFF
--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/UserFiles/DBMgmt/KeepDbMgtConfigByName.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/UserFiles/DBMgmt/KeepDbMgtConfigByName.toml
@@ -11,5 +11,6 @@ WordList = ["SqlStudio\\.bin",
 "\\.psql_history",
 "\\.pgpass",
 "\\.dbeaver-data-sources\\.xml",
+"credentials-config.json",
 "robomongo\\.json"]
 Triage = "Red"

--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/UserFiles/DBMgmt/KeepDbMgtConfigByName.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/UserFiles/DBMgmt/KeepDbMgtConfigByName.toml
@@ -11,6 +11,6 @@ WordList = ["SqlStudio\\.bin",
 "\\.psql_history",
 "\\.pgpass",
 "\\.dbeaver-data-sources\\.xml",
-"credentials-config.json",
+"credentials-config\\.json",
 "robomongo\\.json"]
 Triage = "Red"

--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/UserFiles/DBMgmt/KeepDbMgtConfigByName.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/UserFiles/DBMgmt/KeepDbMgtConfigByName.toml
@@ -12,5 +12,6 @@ WordList = ["SqlStudio\\.bin",
 "\\.pgpass",
 "\\.dbeaver-data-sources\\.xml",
 "credentials-config\\.json",
+"dbvis\\.xml",
 "robomongo\\.json"]
 Triage = "Red"


### PR DESCRIPTION
By default, DBeaver stores credentials in an AES encrypted JSON file. The key is known, as stated in https://dbeaver.com/docs/wiki/Project-security/ This can then be decrypted with openssl or another tool (see https://stackoverflow.com/questions/39928401/recover-db-password-stored-in-my-dbeaver-connection).

For DBVis the principle is similar, but with a password and a salt and PBEWithMD5AndDES, see https://gist.github.com/gerry/c4602c23783d894b8d96 or https://gist.github.com/marcgeld/e484fe918d8cc14358edadd3f3ad3295