### PR TITLE
Update KeepFilenameContainsPamOrPwdVault.toml

### DIFF
--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/BusinessDocs/ByPartialName/KeepFilenameContainsPamOrPwdVault.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/BusinessDocs/ByPartialName/KeepFilenameContainsPamOrPwdVault.toml
@@ -8,6 +8,7 @@ WordListType = "Contains"
 MatchLength = 0
 WordList = ["passw",
 "secret",
+"credential",
 "thycotic",
 "cyberark"]
 Triage = "Green"


### PR DESCRIPTION
Proposing to add 'credential' to the search terms based on discovery of this term used for naming of interesting files in a few environments investigated via manual scanning.