### PR TITLE
Minor AWS-related rule additions and updates

### DIFF
--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Code/KeepAwsKeysInCode.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Code/KeepAwsKeysInCode.toml
@@ -7,5 +7,5 @@ MatchLocation = "FileContentAsString"
 WordListType = "Regex"
 MatchLength = 0
 WordList = ["aws[_\\-\\.]?key",
-"(\\s|\\'|\\\"|\\^|=)(A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}(\\s|\\'|\\\"|$)"]
+"(\\s|\\'|\\\"|\\^|=)(A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z2-7]{12,16}(\\s|\\'|\\\"|$)"]
 Triage = "Red"

--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Code/KeepS3URIPrefixInCode
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Code/KeepS3URIPrefixInCode
@@ -1,0 +1,10 @@
+[[ClassifierRules]]
+EnumerationScope = "ContentsEnumeration"
+RuleName = "KeepS3URIPrefixInCode"
+MatchAction = "Snaffle"
+Description = "Files with content matching an AWS S3 or Apache Hadoop S3A URI Prefix"
+MatchLocation = "FileContentAsString"
+WordListType = "Regex"
+MatchLength = 0
+WordList = ["s3[a]?:\\/\\/[a-zA-Z0-9\\-\\+\\/]{2,16}"]
+Triage = "Yellow"

--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Code/KeepS3UriPrefixInCode.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Code/KeepS3UriPrefixInCode.toml
@@ -1,6 +1,6 @@
 [[ClassifierRules]]
 EnumerationScope = "ContentsEnumeration"
-RuleName = "KeepS3URIPrefixInCode"
+RuleName = "KeepS3UriPrefixInCode"
 MatchAction = "Snaffle"
 Description = "Files with content matching an AWS S3 or Apache Hadoop S3A URI Prefix"
 MatchLocation = "FileContentAsString"


### PR DESCRIPTION
- Create KeepS3UriPrefixInCode to locate common `s3://...` and `s3a://...` strings
- Modify KeepAwsKeysInCode to allow for length-16 access keys
- Modify KeepAwsKeysInCode to only allow the numbers 2-7 to appear in AWS Access Key IDs