### PR TITLE
Dfsv2 sharenamefix

### DIFF
--- a/SnaffCore/ActiveDirectory/DfsFinder.cs
+++ b/SnaffCore/ActiveDirectory/DfsFinder.cs
@@ -115,7 +115,7 @@ namespace SnaffCore.ActiveDirectory
 
                     var target_list = resEnt.GetPropertyAsBytes(@"msdfs-targetlistv2");
                     var xml = new XmlDocument();
-                    string thing = System.Text.Encoding.Unicode.GetString(target_list.Skip(2).Take(target_list.Length - 1 + 1 - 2).ToArray());
+                    //string thing = System.Text.Encoding.Unicode.GetString(target_list.Skip(2).Take(target_list.Length - 1 + 1 - 2).ToArray());
                     xml.LoadXml(System.Text.Encoding.Unicode.GetString(target_list.Skip(2).Take(target_list.Length - 1 + 1 - 2).ToArray()));
 
                     if (xml.FirstChild != null)
@@ -126,11 +126,17 @@ namespace SnaffCore.ActiveDirectory
                             {
                                 try
                                 {
-                                    var Target = node.InnerText;
+                                    var Target = babbynode.InnerText;
                                     if (Target.Contains(@"\"))
                                     {
                                         var DFSroot = Target.Split('\\')[3];
-                                        string ShareName = resEnt.GetProperty(@"msdfs-linkpathv2").Replace("/","\\");
+                                                                                
+                                        string ShareName = resEnt.GetProperty(@"msdfs-linkpathv2").Replace("/","\\");                                        
+                                        if(ShareName == "\\ITPDocs")
+                                        {
+                                            Console.WriteLine("Found {0}", ShareName);
+                                        }
+
                                         // FIX  DFS V2 shares have the share name in the DFSroot, don't double-up
                                         DFSShares.Add(new DFSShare {
                                             Name = $@"{DFSroot}",

--- a/SnaffCore/ActiveDirectory/DfsFinder.cs
+++ b/SnaffCore/ActiveDirectory/DfsFinder.cs
@@ -131,7 +131,12 @@ namespace SnaffCore.ActiveDirectory
                                     {
                                         var DFSroot = Target.Split('\\')[3];
                                         string ShareName = resEnt.GetProperty(@"msdfs-linkpathv2").Replace("/","\\");
-                                        DFSShares.Add(new DFSShare { Name = $@"{DFSroot}{ShareName}", RemoteServerName = Target.Split('\\')[2], DFSNamespace = dfsnamespace });
+                                        // FIX  DFS V2 shares have the share name in the DFSroot, don't double-up
+                                        DFSShares.Add(new DFSShare {
+                                            Name = $@"{DFSroot}",
+                                            RemoteServerName = Target.Split('\\')[2],
+                                            DFSNamespace = dfsnamespace }
+                                        );
                                     }
                                 }
                                 catch (Exception e)


### PR DESCRIPTION
Some changes that were necessary (at least in my environment) to associate SMB shares with their targets in DFS v2/2008 namespaces.  I've only tested it here (mix of V1 and V2 namespaces) so it's possible there are other scenarios to cover.