### PR TITLE
Small fix to DFSv2 discovery method

### DIFF
--- a/SnaffCore/ActiveDirectory/AdData.cs
+++ b/SnaffCore/ActiveDirectory/AdData.cs
@@ -130,7 +130,7 @@ namespace SnaffCore.ActiveDirectory
                 {
                     // Construct the UNC path to this DFS share and add it to the list.  
                     // We use this structure as a to-do list in the ShareFinder code, skipping DFS shares that have already been processed
-                    string dfsShareNamespacePath = @"\\" + _targetDomain + @"\" + dfsShare.DFSNamespace;
+                    string dfsShareNamespacePath = @"\\" + _targetDomain + @"\" + dfsShare.DFSFolderPath;
                     List<string> hostnames = new List<string>();
 
                     if (!_dfsNamespacePaths.Contains(dfsShareNamespacePath))
@@ -156,7 +156,7 @@ namespace SnaffCore.ActiveDirectory
                     // Add these paths as keys in the dictionary
                     foreach (string h in hostnames)
                     {
-                        realPath = String.Format(@"\\{0}\{1}", h, dfsShare.Name);
+                        realPath = String.Format(@"\\{0}\{1}", h, dfsShare.RemoteShareName);
 
                         if (!_dfsSharesDict.ContainsKey(realPath))
                         {

--- a/SnaffCore/ActiveDirectory/DfsFinder.cs
+++ b/SnaffCore/ActiveDirectory/DfsFinder.cs
@@ -11,9 +11,9 @@ namespace SnaffCore.ActiveDirectory
 {
     public class DFSShare
     {
-        public string Name { get; set; }
+        public string RemoteShareName { get; set; }
         public string RemoteServerName { get; set; }
-        public string DFSNamespace { get; set; }
+        public string DFSFolderPath { get; set; }
     }
 
     class DfsFinder
@@ -61,9 +61,9 @@ namespace SnaffCore.ActiveDirectory
 
                                     DFSShares.Add(new DFSShare
                                     {
-                                        Name = resEnt.GetProperty("name"),
+                                        RemoteShareName = resEnt.GetProperty("name"),
                                         RemoteServerName = name.Split(new char[] { '\\' })[2],
-                                        DFSNamespace = dfsnamespace
+                                        DFSFolderPath = dfsnamespace
                                     });
                                 }
                             }
@@ -115,7 +115,6 @@ namespace SnaffCore.ActiveDirectory
 
                     var target_list = resEnt.GetPropertyAsBytes(@"msdfs-targetlistv2");
                     var xml = new XmlDocument();
-                    //string thing = System.Text.Encoding.Unicode.GetString(target_list.Skip(2).Take(target_list.Length - 1 + 1 - 2).ToArray());
                     xml.LoadXml(System.Text.Encoding.Unicode.GetString(target_list.Skip(2).Take(target_list.Length - 1 + 1 - 2).ToArray()));
 
                     if (xml.FirstChild != null)
@@ -126,17 +125,17 @@ namespace SnaffCore.ActiveDirectory
                             {
                                 try
                                 {
-                                    var Target = babbynode.InnerText;
-                                    if (Target.Contains(@"\"))
+                                    var target = babbynode.InnerText;
+                                    if (target.Contains(@"\"))
                                     {
-                                        var DFSroot = Target.Split('\\')[3];                                                                                
-                                        string ShareName = resEnt.GetProperty(@"msdfs-linkpathv2").Replace("/","\\");                                        
+                                        var targetShareName = target.Split('\\')[3];                                                                                
+                                        string dfsLeafName = resEnt.GetProperty(@"msdfs-linkpathv2").Replace("/","\\");                                        
 
-                                        // FIX  DFS V2 shares have the share name in the DFSroot, don't double-up
                                         DFSShares.Add(new DFSShare {
-                                            Name = $@"{DFSroot}",
-                                            RemoteServerName = Target.Split('\\')[2],
-                                            DFSNamespace = dfsnamespace }
+                                                RemoteShareName = $@"{targetShareName}",
+                                                RemoteServerName = target.Split('\\')[2],
+                                                DFSFolderPath = $@"{dfsnamespace}{dfsLeafName}"
+                                            }
                                         );
                                     }
                                 }
@@ -349,8 +348,8 @@ namespace SnaffCore.ActiveDirectory
                             var share = new DFSShare();
 
                             string[] target_parts = target.Split(new char[] { '\\' });
-                            share.DFSNamespace = dfsns;
-                            share.Name = target_parts[3];
+                            share.DFSFolderPath = dfsns;
+                            share.RemoteShareName = target_parts[3];
                             share.RemoteServerName = target_parts[2];
 
                             shares.Add(share);


### PR DESCRIPTION
- Changed the DFSv2 path calculation so that the namespace and folder/leaf name are concatenated (ensuring a 1:1 relationship between the discovered share (on the server) and the DFS path.    The old method had been matching server shares to DFS namespaces, which were broader
- Renamed several properties and variable for clarity