### PR TITLE
Fix NullReferenceException when ComputerExclusions is not initialised

### DIFF
--- a/SnaffCore/Config/Options.cs
+++ b/SnaffCore/Config/Options.cs
@@ -19,7 +19,7 @@ namespace SnaffCore.Config
         public string[] ComputerTargets { get; set; }
         public string ComputerTargetsLdapFilter { get; set; } = "(objectClass=computer)";
         public string ComputerExclusionFile { get; set; }
-        public string[] ComputerExclusions { get; set; }
+        public List<string> ComputerExclusions { get; set; } = new List<string>();
         public bool ScanSysvol { get; set; } = true;
         public bool ScanNetlogon { get; set; } = true;
         public bool ScanFoundShares { get; set; } = true;

--- a/Snaffler/Config.cs
+++ b/Snaffler/Config.cs
@@ -227,7 +227,7 @@ namespace Snaffler
                     }
                     if (compExclusions.Count > 0)
                     {
-                        parsedConfig.ComputerExclusions = compExclusions.ToArray();
+                        parsedConfig.ComputerExclusions = compExclusions;
                         parsedConfig.ComputerExclusionFile = compExclusionArg.Value;
                     }
                     else


### PR DESCRIPTION
`ComputerExclusions` being `null` caused `NullReferenceException` errors. These could only be seen when running with debug or trace verbosity.