### PR TITLE
Adds MDE for Linux Configuration File

### DIFF
--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Infrastructure/DeploymentAutomation/KeepDefenderConfigByName.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Infrastructure/DeploymentAutomation/KeepDefenderConfigByName.toml
@@ -6,5 +6,5 @@ Description = "Files containing Defender Configs are very interesting."
 MatchLocation = "FileName"
 WordListType = "Exact"
 MatchLength = 0
-WordList = ["SensorConfiguration.json"]
+WordList = ["SensorConfiguration.json","mdatp_managed.json"]
 Triage = "Yellow"


### PR DESCRIPTION
Adds MDE for Linux configuration file (no credentials but contains engine exclusions and other preferences): [Set preferences for Microsoft Defender for Endpoint on Linux](https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/linux-preferences?view=o365-worldwide)