### PR TITLE
Adds Kerberos related Filerules

### DIFF
--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Infrastructure/NixKerberos/KeepKerberosCredentialsByExtension.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Infrastructure/NixKerberos/KeepKerberosCredentialsByExtension.toml
@@ -1,0 +1,12 @@
+[[ClassifierRules]]
+EnumerationScope = "FileEnumeration"
+RuleName = "KeepKerberosCredentialsByExtension"
+MatchAction = "Snaffle"
+Description = "Files with these extensions are interesting."
+MatchLocation = "FileExtension"
+WordListType = "Exact"
+MatchLength = 0
+WordList = [
+"\\.keytab",
+"\\.CCACHE"]
+Triage = "Yellow"

--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Infrastructure/NixKerberos/KeepKerberosCredentialsByName.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Infrastructure/NixKerberos/KeepKerberosCredentialsByName.toml
@@ -1,0 +1,11 @@
+[[ClassifierRules]]
+EnumerationScope = "FileEnumeration"
+RuleName = "KeepKerberosCredentialsByName"
+MatchAction = "Snaffle"
+Description = "Files with these names are interesting."
+MatchLocation = "FileName"
+WordListType = "Regex"
+MatchLength = 0
+WordList = [
+"krb5cc_.*"]
+Triage = "Yellow"


### PR DESCRIPTION
This adds two FileRules targeting [Kerberos-related credential files](https://web.mit.edu/kerberos/krb5-latest/doc/mitK5defaults.html). 

**NB!** Not tested in production.

![image](https://github.com/SnaffCon/Snaffler/assets/17042203/1f32c6f4-073e-48d7-809c-ca4ff17b0e4a)