### PR TITLE
Change an existing rule to find more candy.

### DIFF
--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Code/KeepPassOrKeyInCode.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Code/KeepPassOrKeyInCode.toml
@@ -12,7 +12,7 @@ WordList = ["passw?o?r?d\\s*=\\s*[\\'\\\"][^\\'\\\"]....",
 "passw?o?r?d?>.{3,2000}</pass",
 "api[kK]ey>\\s*[^\\s<]+\\s*<",
 "[_\\-\\.]oauth\\s*=\\s*[\\'\\\"][^\\'\\\"]....",
-"client_secret\\s*=\\s*[\\'\\\"][^\\'\\\"]....",
+"client_secret\\s*=*\\s*",
 "<ExtendedMatchKey>ClientAuth",
 "GIUserPassword"
 ]


### PR DESCRIPTION
**TL;DR**
Change rule for more candy.

**Long story**
In engagements, we encounter more and more hybrid environments (especially Azure).
Therefore, I was wondering if Snaffler identifies secrets in Azure/Entra related scripts.
Therefore, I tested several authentication methods with several Azure related tool (Azure CLI, Azure PowerShell, MS Graph, Exchange Online PNP, native API calls etc.).

Snaffler catches all scripts for tools which require a PS password object 😄 .
However, it does not catch the secret in some cases 😢 .

Sometimes customer do not use PowerShell module but native API call (example with curl). The string _client_secret_ is currently not detected if the secret is not quoted.

The current rule (client_secret\\s*=\\s*[\\'\\\"][^\\'\\\"]....) in the file KeepPassOrKeyInCode.toml catches stuff like:
_client_secret = 'SuperPassword1!'
client_secret = "SuperPassword1!"_

But it will miss client secrets which are not quoted:
_client_secret = SuperPassword1!
client_secret = $MyPW_

At least using the example by Microsoft (using CURL) the passwords are not quoted:
References: https://learn.microsoft.com/en-us/graph/auth-v2-user?tabs=curl#step-2-request-an-access-token

Therefore, I suggest to change the current regex to catch all those cases:
Old: _client_secret\\s*=\\s*[\\'\\\"][^\\'\\\"]...._
New: _client_secret\\s*=*\\s*_

Using this changed rule, all credentials (quoted and unquoted) are identified:
![2](https://github.com/user-attachments/assets/20af21ca-02f0-4dc0-b7a4-23ef4e3962eb)
(Parsed Snaffler output file)


