### PR TITLE
Add user impersonation from credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The key incantations are:
 
 `-p` Path to a directory full of .toml formatted rules. Snaffler will load all of these in place of the default ruleset.
 
+`--username` Username of an account that you want to impersonate
+
+`--password` Password of an account that you want to impersonate
+
 ## What does any of this log output mean?
 
 Hopefully this annotated example will help:

--- a/SnaffCore/ActiveDirectory/AdData.cs
+++ b/SnaffCore/ActiveDirectory/AdData.cs
@@ -72,7 +72,7 @@ namespace SnaffCore.ActiveDirectory
         {
             string ldapBase = $"CN=Partitions,CN=Configuration,DC={_targetDomain.Replace(".", ",DC=")}";
 
-            DirectorySearch ds = new DirectorySearch(_targetDomain, _targetDc, ldapBase, null, null, 0, false);
+            DirectorySearch ds = new DirectorySearch(_targetDomain, _targetDc, ldapBase, MyOptions.Username, MyOptions.Password, 0, false);
 
             string[] ldapProperties = new string[] { "netbiosname"};
             string ldapFilter = string.Format("(&(objectcategory=Crossref)(dnsRoot={0})(netBIOSName=*))",_targetDomain);
@@ -107,7 +107,7 @@ namespace SnaffCore.ActiveDirectory
             }
 
             _targetDomainNetBIOSName = GetNetBiosDomainName();
-            DirectorySearch directorySearch = new DirectorySearch(_targetDomain, _targetDc);
+            DirectorySearch directorySearch = new DirectorySearch(_targetDomain, _targetDc, null, MyOptions.Username, MyOptions.Password);
             _directorySearch = directorySearch;
         }
 

--- a/SnaffCore/ActiveDirectory/DirectorySearch.cs
+++ b/SnaffCore/ActiveDirectory/DirectorySearch.cs
@@ -31,13 +31,10 @@ namespace SnaffCore.ActiveDirectory.LDAP
         //Thread-safe storage for our Ldap Connection Pool
         private readonly ConcurrentBag<LdapConnection> _connectionPool = new ConcurrentBag<LdapConnection>();
 
-        public DirectorySearch(string domainName, string domainController, string ldapUserName = null, string ldapPassword = null, int ldapPort = 0, bool secureLdap = false) :
-            this(domainName, domainController, $"DC={domainName.Replace(".", ",DC=")}", ldapUserName, ldapPassword, ldapPort, secureLdap){ }
-
-        public DirectorySearch(string domainName, string domainController, string baseLdapPath, string ldapUserName = null, string ldapPassword = null, int ldapPort = 0, bool secureLdap = false)
+        public DirectorySearch(string domainName, string domainController, string baseLdapPath = null, string ldapUserName = null, string ldapPassword = null, int ldapPort = 0, bool secureLdap = false)
         {
             _domainName = domainName;
-            _baseLdapPath = baseLdapPath;
+            _baseLdapPath = baseLdapPath ?? $"DC={domainName.Replace(".", ",DC=")}";
             _domainController = domainController;
             _domainGuidMap = new Dictionary<string, string>();
             _ldapUsername = ldapUserName;

--- a/SnaffCore/Concurrency/BlockingTaskScheduler.cs
+++ b/SnaffCore/Concurrency/BlockingTaskScheduler.cs
@@ -62,7 +62,21 @@ namespace SnaffCore.Concurrency
                     // okay, let's add the thing
                     proceed = true;
 
-                    _taskFactory.StartNew(action, _cancellationSource.Token);
+                    void actionWithImpersonation()
+                    {
+                        Impersonator.StartImpersonating();
+
+                        try
+                        {
+                            action();
+                        }
+                        finally
+                        {
+                            Impersonator.StopImpersonating();
+                        }
+                    }
+
+                    _taskFactory.StartNew(actionWithImpersonation, _cancellationSource.Token);
                 }
             }
         }

--- a/SnaffCore/Concurrency/BlockingTaskScheduler.cs
+++ b/SnaffCore/Concurrency/BlockingTaskScheduler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -64,7 +65,12 @@ namespace SnaffCore.Concurrency
 
                     void actionWithImpersonation()
                     {
-                        Impersonator.StartImpersonating();
+                        bool impersonateResult = Impersonator.StartImpersonating();
+                        if (!impersonateResult)
+                        {
+                            int errorCode = Marshal.GetLastWin32Error();
+                            throw new Exception($"[Error Code {errorCode}] Failed to impersonate {Impersonator.GetUsername()}.");
+                        }
 
                         try
                         {

--- a/SnaffCore/Config/Options.cs
+++ b/SnaffCore/Config/Options.cs
@@ -58,6 +58,10 @@ namespace SnaffCore.Config
         public string TargetDc { get; set; }
         public bool LogDeniedShares { get; set; } = false; 
 
+        // User Authentication Options
+        public string Username { get; set; }
+        public string Password { get; set; }
+
         // FileScanner Options
         public bool DomainUserRules { get; set; } = false;
         public int DomainUserMinLen { get; set; } = 6;

--- a/SnaffCore/Impersonator.cs
+++ b/SnaffCore/Impersonator.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using SnaffCore.Config;
+
+namespace SnaffCore
+{
+    public class Impersonator
+    {
+        private static IntPtr _userHandle = IntPtr.Zero;
+
+        public static bool Login(string domain, string username, string password)
+        {
+            if (_userHandle != IntPtr.Zero)
+            {
+                return true;
+            }
+
+            return LogonUser(username, domain, password, 2, 0, ref _userHandle);
+        }
+
+        public static bool StartImpersonating()
+        {
+            if (_userHandle == IntPtr.Zero)
+            {
+                return false;
+            }
+
+            return ImpersonateLoggedOnUser(_userHandle);
+        }
+
+        public static bool StopImpersonating()
+        {
+            if (_userHandle == IntPtr.Zero)
+            {
+                return true;
+            }
+
+            return RevertToSelf();
+        }
+
+        public static bool Free()
+        {
+            if (_userHandle == IntPtr.Zero)
+            {
+                return true;
+            }
+
+            return CloseHandle(_userHandle);
+        }
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool LogonUser(
+            string lpszUsername,
+            string lpszDomain,
+            string lpszPassword,
+            int dwLogonType,
+            int dwLogonProvider,
+            ref IntPtr phToken
+        );
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+        private static extern bool ImpersonateLoggedOnUser(IntPtr hToken);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Auto)]
+        private static extern bool RevertToSelf();
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        private static extern bool CloseHandle(IntPtr handle);
+    }
+}

--- a/SnaffCore/Impersonator.cs
+++ b/SnaffCore/Impersonator.cs
@@ -23,7 +23,7 @@ namespace SnaffCore
         {
             if (_userHandle == IntPtr.Zero)
             {
-                return false;
+                return true;
             }
 
             return ImpersonateLoggedOnUser(_userHandle);

--- a/SnaffCore/Impersonator.cs
+++ b/SnaffCore/Impersonator.cs
@@ -1,16 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
-using SnaffCore.Config;
 
 namespace SnaffCore
 {
     public class Impersonator
     {
         private static IntPtr _userHandle = IntPtr.Zero;
+        private static string _username = string.Empty;
 
         public static bool Login(string domain, string username, string password)
         {
@@ -19,6 +15,7 @@ namespace SnaffCore
                 return true;
             }
 
+            _username = username;
             return LogonUser(username, domain, password, 2, 0, ref _userHandle);
         }
 
@@ -52,6 +49,11 @@ namespace SnaffCore
             return CloseHandle(_userHandle);
         }
 
+        public static string GetUsername()
+        {
+            return _username;
+        }
+
         [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool LogonUser(
             string lpszUsername,
@@ -62,7 +64,7 @@ namespace SnaffCore
             ref IntPtr phToken
         );
 
-        [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool ImpersonateLoggedOnUser(IntPtr hToken);
 
         [DllImport("advapi32.dll", CharSet = CharSet.Auto)]

--- a/SnaffCore/SnaffCon.cs
+++ b/SnaffCore/SnaffCon.cs
@@ -16,6 +16,7 @@ using System.Timers;
 using static SnaffCore.Config.Options;
 using Timer = System.Timers.Timer;
 using System.Net;
+using System.Runtime.InteropServices;
 
 namespace SnaffCore
 {
@@ -82,7 +83,12 @@ namespace SnaffCore
 
         public void Execute()
         {
-            Impersonator.StartImpersonating();
+            bool impersonateResult = Impersonator.StartImpersonating();
+            if (!impersonateResult)
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                Mq.Error($"[Error Code {errorCode}] Failed to impersonate {Impersonator.GetUsername()}.");
+            }
 
             StartTime = DateTime.Now;
             // This is the main execution thread.

--- a/SnaffCore/SnaffCon.cs
+++ b/SnaffCore/SnaffCon.cs
@@ -82,6 +82,8 @@ namespace SnaffCore
 
         public void Execute()
         {
+            Impersonator.StartImpersonating();
+
             StartTime = DateTime.Now;
             // This is the main execution thread.
             Timer statusUpdateTimer =
@@ -157,6 +159,8 @@ namespace SnaffCore
             Mq.Info("Finished at " + finished.ToLocalTime());
             Mq.Info("Snafflin' took " + runSpan);
             Mq.Finish();
+
+            Impersonator.StopImpersonating();
         }
 
         private void DomainDfsDiscovery()

--- a/SnaffCore/SnaffCore.csproj
+++ b/SnaffCore/SnaffCore.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Config\ClassifierOptions.cs" />
     <Compile Include="Config\Options.cs" />
     <Compile Include="Classifiers\ClassifierRule.cs" />
+    <Compile Include="Impersonator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ShareFind\ShareFinder.cs" />
     <Compile Include="FileScan\FileScanner.cs" />

--- a/Snaffler/Config.cs
+++ b/Snaffler/Config.cs
@@ -108,6 +108,9 @@ namespace Snaffler
                 "Interval between status updates (in minutes) also acts as a timeout for AD data to be gathered via LDAP. Turn this knob up if you aren't getting any computers from AD when you run Snaffler through a proxy or other slow link. Default = 5");
             // list of letters i haven't used yet: gnqw
 
+            ValueArgument<string> UsernameArg = new ValueArgument<string>("username");
+            ValueArgument<string> PasswordArg = new ValueArgument<string>("password");
+
             CommandLineParser.CommandLineParser parser = new CommandLineParser.CommandLineParser();
             parser.Arguments.Add(timeOutArg);
             parser.Arguments.Add(configFileArg);
@@ -132,6 +135,8 @@ namespace Snaffler
             parser.Arguments.Add(ruleDirArg);
             parser.Arguments.Add(logType);
             parser.Arguments.Add(compExclusionArg);
+            parser.Arguments.Add(UsernameArg);
+            parser.Arguments.Add(PasswordArg);
 
             // extra check to handle builtin behaviour from cmd line arg parser
             if ((args.Contains("--help") || args.Contains("/?") || args.Contains("help") || args.Contains("-h") || args.Length == 0))
@@ -378,6 +383,16 @@ namespace Snaffler
                         parsedConfig = Toml.ReadFile<Options>(configFile, settings);
                         Mq.Info("Read config file from " + configFile);
                     }
+                }
+
+                if (UsernameArg.Parsed)
+                {
+                    parsedConfig.Username = UsernameArg.Value;
+                }
+
+                if (PasswordArg.Parsed)
+                {
+                    parsedConfig.Password = PasswordArg.Value;
                 }
 
                 if (!parsedConfig.LogToConsole && !parsedConfig.LogToFile)

--- a/Snaffler/SnaffleRunner.cs
+++ b/Snaffler/SnaffleRunner.cs
@@ -193,9 +193,10 @@ namespace Snaffler
                 //-------------------------------------------
 
                 // Check if user credentials were specified
-                if ((Options.TargetDomain != null) && (Options.Username != null) && (Options.Password != null))
+                if (Options.Username != null)
                 {
-                    Impersonator.Login(Options.TargetDomain, Options.Username, Options.Password);
+                    Mq.Info($"Impersonating {Options.Username}.");
+                    Impersonator.Login(Options.TargetDomain ?? Environment.UserDomainName, Options.Username, Options.Password ?? "");
                     Impersonator.StartImpersonating();
                 }
 

--- a/Snaffler/SnaffleRunner.cs
+++ b/Snaffler/SnaffleRunner.cs
@@ -211,6 +211,8 @@ namespace Snaffler
                         int errorCode = Marshal.GetLastWin32Error();
                         throw new Exception($"[Error Code {errorCode}] Failed to impersonate {Impersonator.GetUsername()}.");
                     }
+
+                    Options.CurrentUser = Options.Username;
                 }
 
                 if (Options.Snaffle && (Options.SnafflePath.Length > 4))

--- a/Snaffler/SnaffleRunner.cs
+++ b/Snaffler/SnaffleRunner.cs
@@ -192,6 +192,13 @@ namespace Snaffler
 
                 //-------------------------------------------
 
+                // Check if user credentials were specified
+                if ((Options.TargetDomain != null) && (Options.Username != null) && (Options.Password != null))
+                {
+                    Impersonator.Login(Options.TargetDomain, Options.Username, Options.Password);
+                    Impersonator.StartImpersonating();
+                }
+
                 if (Options.Snaffle && (Options.SnafflePath.Length > 4))
                 {
                     Directory.CreateDirectory(Options.SnafflePath);
@@ -217,6 +224,11 @@ namespace Snaffler
             {
                 Console.WriteLine(e.ToString());
                 DumpQueue();
+            }
+            finally
+            {
+                Impersonator.StopImpersonating();
+                Impersonator.Free();
             }
         }
 


### PR DESCRIPTION
The changes in this pull request add the `--username` and `--password` options, which when specified, will authenticate and impersonate the given user.

This will allow Snaffler to operate as if it were being run in the context of another domain user without having to run the tool while logged in as that user. By default, if a domain is not specified, it will use the domain of the current user, and if a password is not specified it will default to an empty string.

I have tested the changes here and they seem to work, but it is possible I am missing something since I am not the most familiar with this tool. I am able to get access to a share that only the impersonated user has access to.