### PR TITLE
Add Resume Support

### DIFF
--- a/SnaffCore/Config/Options.cs
+++ b/SnaffCore/Config/Options.cs
@@ -14,6 +14,10 @@ namespace SnaffCore.Config
     {
         public static Options MyOptions { get; set; }
 
+        // Pause and resume functionality
+        public string TaskFile { get; set; }
+        public string ResumeFrom { get; set; }
+
         // Manual Targeting Options
         public List<string> PathTargets { get; set; } = new List<string>();
         public string[] ComputerTargets { get; set; }

--- a/SnaffCore/ShareFind/ShareFinder.cs
+++ b/SnaffCore/ShareFind/ShareFinder.cs
@@ -17,7 +17,7 @@ namespace SnaffCore.ShareFind
     public class ShareFinder
     {
         private BlockingMq Mq { get; set; }
-        private BlockingStaticTaskScheduler TreeTaskScheduler { get; set; }
+        private TreeTaskScheduler TreeTaskScheduler { get; set; }
         private TreeWalker TreeWalker { get; set; }
         //private EffectivePermissions effectivePermissions { get; set; } = new EffectivePermissions(MyOptions.CurrentUser);
 
@@ -184,18 +184,7 @@ namespace SnaffCore.ShareFind
                             if (MyOptions.ScanFoundShares)
                             {
                                 Mq.Trace("Creating a TreeWalker task for " + shareResult.SharePath);
-                                TreeTaskScheduler.New(() =>
-                                {
-                                    try
-                                    {
-                                        TreeWalker.WalkTree(shareResult.SharePath);
-                                    }
-                                    catch (Exception e)
-                                    {
-                                        Mq.Error("Exception in TreeWalker task for share " + shareResult.SharePath);
-                                        Mq.Error(e.ToString());
-                                    }
-                                });
+                                TreeTaskScheduler.New(TreeWalker.WalkTree, shareResult.SharePath);
                             }
                             Mq.ShareResult(shareResult);
                         }

--- a/SnaffCore/TreeWalk/TreeWalker.cs
+++ b/SnaffCore/TreeWalk/TreeWalker.cs
@@ -10,8 +10,8 @@ namespace SnaffCore.TreeWalk
     public class TreeWalker
     {
         private BlockingMq Mq { get; set; }
-        private BlockingStaticTaskScheduler FileTaskScheduler { get; set; }
-        private BlockingStaticTaskScheduler TreeTaskScheduler { get; set; }
+        private FileTaskScheduler FileTaskScheduler { get; set; }
+        private TreeTaskScheduler TreeTaskScheduler { get; set; }
         private FileScanner FileScanner { get; set; }
 
         public TreeWalker()
@@ -38,18 +38,19 @@ namespace SnaffCore.TreeWalk
                 // check if we actually like the files
                 foreach (string file in files)
                 {
-                    FileTaskScheduler.New(() =>
-                    {
-                        try
-                        {
-                            FileScanner.ScanFile(file);
-                        }
-                        catch (Exception e)
-                        {
-                            Mq.Error("Exception in FileScanner task for file " + file);
-                            Mq.Trace(e.ToString());
-                        }
-                    });
+                    FileTaskScheduler.New(FileScanner.ScanFile, file);
+                    //FileTaskScheduler.New(() =>
+                    //{
+                    //    try
+                    //    {
+                    //        FileScanner.ScanFile(file);
+                    //    }
+                    //    catch (Exception e)
+                    //    {
+                    //        Mq.Error("Exception in FileScanner task for file " + file);
+                    //        Mq.Trace(e.ToString());
+                    //    }
+                    //});
                 }
             }
             catch (UnauthorizedAccessException)
@@ -104,18 +105,19 @@ namespace SnaffCore.TreeWalk
                         }
                         if (scanDir == true)
                         {
-                            TreeTaskScheduler.New(() =>
-                            {
-                                try
-                                {
-                                    WalkTree(dirStr);
-                                }
-                                catch (Exception e)
-                                {
-                                    Mq.Error("Exception in TreeWalker task for dir " + dirStr);
-                                    Mq.Error(e.ToString());
-                                }
-                            });
+                            TreeTaskScheduler.New(WalkTree, dirStr);
+                            //TreeTaskScheduler.New(() =>
+                            //{
+                            //    try
+                            //    {
+                            //        WalkTree(dirStr);
+                            //    }
+                            //    catch (Exception e)
+                            //    {
+                            //        Mq.Error("Exception in TreeWalker task for dir " + dirStr);
+                            //        Mq.Error(e.ToString());
+                            //    }
+                            //});
                         }
                         else
                         {

--- a/SnaffCore/TreeWalk/TreeWalker.cs
+++ b/SnaffCore/TreeWalk/TreeWalker.cs
@@ -39,18 +39,6 @@ namespace SnaffCore.TreeWalk
                 foreach (string file in files)
                 {
                     FileTaskScheduler.New(FileScanner.ScanFile, file);
-                    //FileTaskScheduler.New(() =>
-                    //{
-                    //    try
-                    //    {
-                    //        FileScanner.ScanFile(file);
-                    //    }
-                    //    catch (Exception e)
-                    //    {
-                    //        Mq.Error("Exception in FileScanner task for file " + file);
-                    //        Mq.Trace(e.ToString());
-                    //    }
-                    //});
                 }
             }
             catch (UnauthorizedAccessException)
@@ -106,18 +94,6 @@ namespace SnaffCore.TreeWalk
                         if (scanDir == true)
                         {
                             TreeTaskScheduler.New(WalkTree, dirStr);
-                            //TreeTaskScheduler.New(() =>
-                            //{
-                            //    try
-                            //    {
-                            //        WalkTree(dirStr);
-                            //    }
-                            //    catch (Exception e)
-                            //    {
-                            //        Mq.Error("Exception in TreeWalker task for dir " + dirStr);
-                            //        Mq.Error(e.ToString());
-                            //    }
-                            //});
                         }
                         else
                         {

--- a/Snaffler/Config.cs
+++ b/Snaffler/Config.cs
@@ -106,6 +106,8 @@ namespace Snaffler
             ValueArgument<string> logType = new ValueArgument<string>('t', "logtype", "Type of log you would like to output. Currently supported options are plain and JSON. Defaults to plain.");
             ValueArgument<string> timeOutArg = new ValueArgument<string>('e', "timeout",
                 "Interval between status updates (in minutes) also acts as a timeout for AD data to be gathered via LDAP. Turn this knob up if you aren't getting any computers from AD when you run Snaffler through a proxy or other slow link. Default = 5");
+            ValueArgument<string> taskFile = new ValueArgument<string>('1', "taskfile", "Save tasks as they are created to a file to allow for resuming mid-operation.");
+            ValueArgument<string> resumeFrom = new ValueArgument<string>('2', "resumefrom", "Resume tasks from a file generated with --taskfile.");
             // list of letters i haven't used yet: gnqw
 
             CommandLineParser.CommandLineParser parser = new CommandLineParser.CommandLineParser();
@@ -132,6 +134,8 @@ namespace Snaffler
             parser.Arguments.Add(ruleDirArg);
             parser.Arguments.Add(logType);
             parser.Arguments.Add(compExclusionArg);
+            parser.Arguments.Add(taskFile);
+            parser.Arguments.Add(resumeFrom);
 
             // extra check to handle builtin behaviour from cmd line arg parser
             if ((args.Contains("--help") || args.Contains("/?") || args.Contains("help") || args.Contains("-h") || args.Length == 0))
@@ -149,6 +153,16 @@ namespace Snaffler
             try
             {
                 parser.ParseCommandLine(args);
+
+                if (taskFile.Parsed)
+                {
+                    parsedConfig.TaskFile = taskFile.Value;
+                }
+
+                if (resumeFrom.Parsed)
+                {
+                    parsedConfig.ResumeFrom = resumeFrom.Value;
+                }
 
                 if (timeOutArg.Parsed && !String.IsNullOrWhiteSpace(timeOutArg.Value))
                 {


### PR DESCRIPTION
This PR adds the feature talked about in #61.

There are two new arguments
- `--taskfile` writes tasks to a file as they are created and completed
- `--resumefrom` takes the file made from the above and dispatches all the pending tasks left in the file. This mode resumes normal operation after dispatching tasks from the file (it also skips any tasks that have been completed already).

As far as I can tell this does not introduce noticeable overhead to the execution. Everything is written in a blocking manner meaning the task does not actually get created until it gets written to the file, this *should* guarantee that all tasks are saved. In addition, if you specify a task file while resuming from another, it will copy over all completed tasks from the old file into the new at the start of execution so you should be able use them even if the program is interrupted after resuming from a task file already.

Let me know if there are any problems, or if I need to make any changes.