### PR TITLE
Update KeepInfraAsCodeConfigByExtension.toml

### DIFF
--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Infrastructure/InfraAsCode/KeepInfraAsCodeConfigByExtension.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Infrastructure/InfraAsCode/KeepInfraAsCodeConfigByExtension.toml
@@ -7,5 +7,6 @@ MatchLocation = "FileExtension"
 WordListType = "Exact"
 MatchLength = 0
 WordList = [    "\\.cscfg",
+"\\.ucs",
 "\\.tfvars"]
 Triage = "Red"


### PR DESCRIPTION
added .ucs file extension for F5 appliance backups, cheers plugger!