### PR TITLE
Add detection for unencrypted PPK files

### DIFF
--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/UserFiles/SSH/KeepSSHKeysByFileExtension.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/UserFiles/SSH/KeepSSHKeysByFileExtension.toml
@@ -1,10 +1,11 @@
 [[ClassifierRules]]
 EnumerationScope = "FileEnumeration"
-RuleName = "KeepSSHKeysByFileExtension"
-MatchAction = "Snaffle"
-Description = "SSHKeys"
+RuleName = "RelayPPKForContentScan"
+MatchAction = "Relay"
+RelayTargets = ["KeepUnencryptedPPK"]
+Description = "PPK files are relayed to content scanning for unencrypted detection"
 MatchLocation = "FileExtension"
 WordListType = "Exact"
 MatchLength = 0
 WordList = ["\\.ppk"]
-Triage = "Black"
+Triage = "Green"

--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/UserFiles/SSH/KeepUnencryptedPPK.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/UserFiles/SSH/KeepUnencryptedPPK.toml
@@ -1,0 +1,11 @@
+[[ClassifierRules]]
+EnumerationScope = "ContentsEnumeration"
+RuleName = "KeepUnencryptedPPK"
+MatchAction = "Snaffle"
+Description = "Unencrypted PPK files (contains 'Encryption: none')"
+MatchLocation = "FileContentAsString"
+WordListType = "Regex"
+MatchLength = 0
+WordList = ["Encryption:\\s*none"]
+Triage = "Black"
+


### PR DESCRIPTION
- Modified KeepSSHKeysByFileExtension.toml to relay .ppk files to content scanning
- Added KeepUnencryptedPPK.toml to detect "Encryption: none" pattern with Black triage

This allows Snaffler to differentiate between encrypted and unencrypted PPK files, flagging only unencrypted ones as high-priority findings.