### PR TITLE
Add functionality to allow inscope/out of scope CIDR targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The key incantations are:
 
 `-n`   Disables computer discovery, takes a comma-separated list of hosts or input file to do share and file discovery on. Note if supplying a file, the input needs to be a path so C:\targets.txt or .\targets.txt as an example.
 
+`-k`   Excludes specific hosts from scanning. Accepts a comma-separated list of hostnames, IPs, and/or CIDR ranges (e.g. `-k 10.1.2.0/24,192.168.5.10`), or a path to a file containing one entry per line. Hostnames are resolved to IPs at startup. CIDR ranges are matched against each computer's resolved IP at scan time.
+
 `-y`   TSV-formats the output.
 
 `-b`   Skips the LAIM rules that will find less-interesting stuff, tune it with a number between 0 and 3.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The key incantations are:
 
 `-k`   Excludes specific hosts from scanning. Accepts a comma-separated list of hostnames, IPs, and/or CIDR ranges (e.g. `-k 10.1.2.0/24,192.168.5.10`), or a path to a file containing one entry per line. Hostnames are resolved to IPs at startup. CIDR ranges are matched against each computer's resolved IP at scan time.
 
+`-q`   Queries AD for computers, then only scans those resolving within the specified CIDRs. Comma-separated. e.g. `-q 10.1.2.0/24,10.1.4.0/24`. Can be combined with `-k` to further exclude specific hosts.
+
 `-y`   TSV-formats the output.
 
 `-b`   Skips the LAIM rules that will find less-interesting stuff, tune it with a number between 0 and 3.

--- a/SnaffCore/Config/Options.cs
+++ b/SnaffCore/Config/Options.cs
@@ -20,6 +20,7 @@ namespace SnaffCore.Config
         public string ComputerTargetsLdapFilter { get; set; } = "(objectClass=computer)";
         public string ComputerExclusionFile { get; set; }
         public List<string> ComputerExclusions { get; set; } = new List<string>();
+        public List<string> CidrInclusions { get; set; } = new List<string>();
         public bool ScanSysvol { get; set; } = true;
         public bool ScanNetlogon { get; set; } = true;
         public bool ScanFoundShares { get; set; } = true;

--- a/SnaffCore/NetworkUtils.cs
+++ b/SnaffCore/NetworkUtils.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace SnaffCore
+{
+    public static class NetworkUtils
+    {
+        // Matches network/prefix notation e.g. 10.1.2.0/24 or 2001:db8::/32
+        public static readonly Regex CidrRegex = new Regex(@"^\S+/\d+$", RegexOptions.Compiled);
+        /// <summary>
+        /// Checks whether an IP address falls within a CIDR range.
+        /// Supports both IPv4 and IPv6.
+        /// </summary>
+        public static bool IsInCidr(IPAddress address, string cidr)
+        {
+            // Split "network/prefixLength" e.g. "10.1.2.0/24" -> ["10.1.2.0", "24"]
+            string[] parts = cidr.Split('/');
+            if (parts.Length != 2 || !int.TryParse(parts[1], out int prefixLength))
+                return false;
+            if (!IPAddress.TryParse(parts[0], out IPAddress network))
+                return false;
+
+            // GetAddressBytes() returns big-endian bytes: 4 for IPv4, 16 for IPv6
+            // Mismatched lengths means comparing IPv4 against IPv6 or vice versa
+            byte[] addrBytes = address.GetAddressBytes();
+            byte[] netBytes = network.GetAddressBytes();
+
+            if (addrBytes.Length != netBytes.Length)
+                return false;
+
+            // Check all bytes that are fully covered by the prefix
+            // e.g. /24 covers 3 full bytes, /20 covers 2 full bytes
+            int fullBytes = prefixLength / 8;
+            int remainingBits = prefixLength % 8;
+
+            for (int i = 0; i < fullBytes; i++)
+            {
+                if (addrBytes[i] != netBytes[i])
+                    return false;
+            }
+
+            // Check the partial byte (if the prefix doesn't fall on a byte boundary)
+            // e.g. /20 has 4 remaining bits: mask = 11110000 = 0xF0
+            // We only compare the masked bits, ignoring the host portion
+            if (remainingBits > 0)
+            {
+                byte mask = (byte)(0xFF << (8 - remainingBits));
+                if ((addrBytes[fullBytes] & mask) != (netBytes[fullBytes] & mask))
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/SnaffCore/SnaffCon.cs
+++ b/SnaffCore/SnaffCon.cs
@@ -290,11 +290,18 @@ namespace SnaffCore
         {
             Mq.Info("Starting to look for readable shares...");
             int excludedCount = 0;
+            int cidrFilteredCount = 0;
+            bool hasCidrInclusions = MyOptions.CidrInclusions.Count > 0;
             foreach (string computer in computerTargets)
             {
                 if (CheckExclusions(computer))
                 {
                     excludedCount++;
+                    continue;
+                }
+                if (hasCidrInclusions && !CheckInclusions(computer))
+                {
+                    cidrFilteredCount++;
                     continue;
                 }
                 // Perform reverse lookup if the computer is an IP address
@@ -339,6 +346,10 @@ namespace SnaffCore
             if (excludedCount > 0)
             {
                 Mq.Info("Excluded " + excludedCount + " of " + computerTargets.Length + " computers from scanning.");
+            }
+            if (cidrFilteredCount > 0)
+            {
+                Mq.Info("CIDR target filter: kept " + (computerTargets.Length - excludedCount - cidrFilteredCount) + " of " + computerTargets.Length + " computers.");
             }
             Mq.Info("Created all sharefinder tasks.");
         }
@@ -402,6 +413,42 @@ namespace SnaffCore
                 if (NetworkUtils.CidrRegex.IsMatch(entry) && NetworkUtils.IsInCidr(address, entry))
                     return true;
             }
+            return false;
+        }
+
+        private bool CheckInclusions(string computer)
+        {
+            // Returns true if the computer resolves to an IP within any of the CIDR inclusions
+            try
+            {
+                IPAddress[] addresses;
+                if (isIP(computer))
+                {
+                    addresses = new[] { IPAddress.Parse(computer) };
+                }
+                else
+                {
+                    addresses = Dns.GetHostEntry(computer).AddressList;
+                }
+
+                foreach (IPAddress addr in addresses)
+                {
+                    foreach (string cidr in MyOptions.CidrInclusions)
+                    {
+                        if (NetworkUtils.IsInCidr(addr, cidr))
+                        {
+                            Mq.Degub("CIDR included " + computer + " at " + addr);
+                            return true;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Mq.Degub(ex.Message);
+            }
+
+            Mq.Degub("CIDR filtered out " + computer);
             return false;
         }
 

--- a/SnaffCore/SnaffCon.cs
+++ b/SnaffCore/SnaffCon.cs
@@ -289,11 +289,12 @@ namespace SnaffCore
         private void ShareDiscovery(string[] computerTargets)
         {
             Mq.Info("Starting to look for readable shares...");
+            int excludedCount = 0;
             foreach (string computer in computerTargets)
             {
                 if (CheckExclusions(computer))
                 {
-                    // skip any that are in the exclusion list
+                    excludedCount++;
                     continue;
                 }
                 // Perform reverse lookup if the computer is an IP address
@@ -334,6 +335,10 @@ namespace SnaffCore
                         Mq.Error(e.ToString());
                     }
                 });
+            }
+            if (excludedCount > 0)
+            {
+                Mq.Info("Excluded " + excludedCount + " of " + computerTargets.Length + " computers from scanning.");
             }
             Mq.Info("Created all sharefinder tasks.");
         }

--- a/SnaffCore/SnaffCon.cs
+++ b/SnaffCore/SnaffCon.cs
@@ -33,6 +33,7 @@ namespace SnaffCore
         private static TreeWalker TreeWalker;
         private static FileScanner FileScanner;
 
+
         private AdData _adData = AdData.AdDataInstance;
 
         private DateTime StartTime { get; set; }
@@ -348,15 +349,16 @@ namespace SnaffCore
             // check if it's an IP already
             if (isIP(computer))
             {
-                // check if it's in the exclusions list
-                if (MyOptions.ComputerExclusions.Contains(computer))
+                IPAddress addr = IPAddress.Parse(computer);
+                // check if it's in the exclusions list or falls within an excluded CIDR
+                if (MyOptions.ComputerExclusions.Contains(computer) || IsInAnyCidr(addr))
                 {
                     // if so, skip it
                     Mq.Degub("Excluded " + computer);
                     return true;
                 }
             }
-            else { 
+            else {
                 try
                 {
                     // resolve it
@@ -364,8 +366,8 @@ namespace SnaffCore
                     // handle multiple IPs in response
                     foreach (IPAddress ipAddress in result.AddressList)
                     {
-                        // if any of them is in the exclusion list
-                        if (MyOptions.ComputerExclusions.Contains(ipAddress.ToString()))
+                        // if any of them is in the exclusion list or falls within an excluded CIDR
+                        if (MyOptions.ComputerExclusions.Contains(ipAddress.ToString()) || IsInAnyCidr(ipAddress))
                         {
                             Mq.Degub("Excluded " + computer + " at " + ipAddress);
 
@@ -385,6 +387,16 @@ namespace SnaffCore
             }
             Mq.Degub("Included " + computer);
 
+            return false;
+        }
+
+        private bool IsInAnyCidr(IPAddress address)
+        {
+            foreach (string entry in MyOptions.ComputerExclusions)
+            {
+                if (NetworkUtils.CidrRegex.IsMatch(entry) && NetworkUtils.IsInCidr(address, entry))
+                    return true;
+            }
             return false;
         }
 

--- a/SnaffCore/SnaffCon.cs
+++ b/SnaffCore/SnaffCon.cs
@@ -343,13 +343,15 @@ namespace SnaffCore
                     }
                 });
             }
+            int postExclusion = computerTargets.Length - excludedCount;
+            int included = postExclusion - cidrFilteredCount;
             if (excludedCount > 0)
             {
-                Mq.Info("Excluded " + excludedCount + " of " + computerTargets.Length + " computers from scanning.");
+                Mq.Info("Excluded " + excludedCount + " of " + computerTargets.Length + " computers (exclusion list or DNS resolution failure).");
             }
             if (cidrFilteredCount > 0)
             {
-                Mq.Info("CIDR target filter: kept " + (computerTargets.Length - excludedCount - cidrFilteredCount) + " of " + computerTargets.Length + " computers.");
+                Mq.Info("CIDR target filter: kept " + included + " of " + postExclusion + " remaining computers.");
             }
             Mq.Info("Created all sharefinder tasks.");
         }

--- a/SnaffCore/SnaffCore.csproj
+++ b/SnaffCore/SnaffCore.csproj
@@ -88,6 +88,7 @@
     <Compile Include="FileScan\FileScanner.cs" />
     <Compile Include="TreeWalk\TreeWalker.cs" />
     <Compile Include="SnaffCon.cs" />
+    <Compile Include="NetworkUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Nett.Coma">

--- a/Snaffler/Config.cs
+++ b/Snaffler/Config.cs
@@ -100,7 +100,7 @@ namespace Snaffler
             SwitchArgument dfsArg = new SwitchArgument('f', "dfs", "Limits Snaffler to finding file shares via DFS, for \"OPSEC\" reasons.", false);
             SwitchArgument findSharesOnlyArg = new SwitchArgument('a', "sharesonly",
                 "Stops after finding shares, doesn't walk their filesystems.", false);
-            ValueArgument<string> compExclusionArg = new ValueArgument<string>('k', "exclusions", "Path to a file containing a list of computers to exclude from scanning.");
+            ValueArgument<string> compExclusionArg = new ValueArgument<string>('k', "exclusions", "Path to a file, or inline comma-separated list, of hostnames/IPs/CIDRs to exclude from scanning. e.g. -k exclusions.txt or -k 10.1.2.0/24,192.168.5.10");
             ValueArgument<string> compTargetArg = new ValueArgument<string>('n', "comptarget", "List of computers in a file(e.g C:\targets.txt), a single Computer (or comma separated list) to target.");
             ValueArgument<string> ruleDirArg = new ValueArgument<string>('p', "rulespath", "Path to a directory full of toml-formatted rules. Snaffler will load all of these in place of the default ruleset.");
             ValueArgument<string> logType = new ValueArgument<string>('t', "logtype", "Type of log you would like to output. Currently supported options are plain and JSON. Defaults to plain.");
@@ -137,7 +137,7 @@ namespace Snaffler
             if ((args.Contains("--help") || args.Contains("/?") || args.Contains("help") || args.Contains("-h") || args.Length == 0))
             {
                 parser.ShowUsage();
-                return null; 
+                return null;
             }
 
             TomlSettings settings = TomlSettings.Create(cfg => cfg
@@ -201,18 +201,41 @@ namespace Snaffler
                 if (compExclusionArg.Parsed)
                 {
                     List<string> compExclusions = new List<string>();
-                    string[] fileLines = File.ReadAllLines(compExclusionArg.Value);
-                    foreach (string line in fileLines)
+                    IEnumerable<string> entries;
+
+                    if (compExclusionArg.Value.Contains(','))
                     {
-                        if (isIP(line))
+                        entries = compExclusionArg.Value.Split(',')
+                            .Select(l => l.Trim())
+                            .Where(l => !string.IsNullOrEmpty(l));
+                    }
+                    else if (SnaffCore.NetworkUtils.CidrRegex.IsMatch(compExclusionArg.Value.Trim()))
+                    {
+                        entries = new[] { compExclusionArg.Value.Trim() };
+                    }
+                    else if (compExclusionArg.Value.Contains(Path.DirectorySeparatorChar))
+                    {
+                        entries = File.ReadAllLines(compExclusionArg.Value)
+                            .Select(l => l.Trim())
+                            .Where(l => !string.IsNullOrEmpty(l));
+                        parsedConfig.ComputerExclusionFile = compExclusionArg.Value;
+                    }
+                    else
+                    {
+                        entries = new[] { compExclusionArg.Value.Trim() };
+                    }
+
+                    foreach (string entry in entries)
+                    {
+                        if (SnaffCore.NetworkUtils.CidrRegex.IsMatch(entry) || isIP(entry))
                         {
-                            compExclusions.Add(line);
+                            compExclusions.Add(entry);
                         }
                         else
                         {
                             try
                             {
-                                IPHostEntry result = Dns.GetHostEntry(line);
+                                IPHostEntry result = Dns.GetHostEntry(entry);
                                 foreach (IPAddress ipAddress in result.AddressList)
                                 {
                                     compExclusions.Add(ipAddress.ToString());
@@ -225,17 +248,17 @@ namespace Snaffler
                             }
                         }
                     }
+
                     if (compExclusions.Count > 0)
                     {
                         parsedConfig.ComputerExclusions = compExclusions;
-                        parsedConfig.ComputerExclusionFile = compExclusionArg.Value;
                     }
                     else
                     {
                         throw new Exception("Failed to get a valid list of excluded computers from the excluded computers list.");
                     }
                 }
-                
+
                 if (compTargetArg.Parsed)
                 {
                     List<string> compTargets = new List<string>();
@@ -336,7 +359,7 @@ namespace Snaffler
                         }
                         parsedConfig.PathTargets.Add(pathTarget);
                     }
-                    
+
                     //Console.WriteLine(parsedConfig.PathTargets[0]);
                     foreach (string pathTarget in parsedConfig.PathTargets)
                     {
@@ -362,7 +385,7 @@ namespace Snaffler
                     Mq.Degub("Requested interest level: " + parsedConfig.InterestLevel);
                 }
 
-                // how many bytes 
+                // how many bytes
                 if (grepContextArg.Parsed)
                 {
                     parsedConfig.MatchContextBytes = grepContextArg.Value;

--- a/Snaffler/Config.cs
+++ b/Snaffler/Config.cs
@@ -102,11 +102,12 @@ namespace Snaffler
                 "Stops after finding shares, doesn't walk their filesystems.", false);
             ValueArgument<string> compExclusionArg = new ValueArgument<string>('k', "exclusions", "Path to a file, or inline comma-separated list, of hostnames/IPs/CIDRs to exclude from scanning. e.g. -k exclusions.txt or -k 10.1.2.0/24,192.168.5.10");
             ValueArgument<string> compTargetArg = new ValueArgument<string>('n', "comptarget", "List of computers in a file(e.g C:\targets.txt), a single Computer (or comma separated list) to target.");
+            ValueArgument<string> cidrTargetArg = new ValueArgument<string>('q', "cidrtarget", "Comma-separated list of CIDRs to target. Queries AD for computers, then only scans those resolving within the specified CIDRs. e.g. -q 10.1.2.0/24,10.1.4.0/24");
             ValueArgument<string> ruleDirArg = new ValueArgument<string>('p', "rulespath", "Path to a directory full of toml-formatted rules. Snaffler will load all of these in place of the default ruleset.");
             ValueArgument<string> logType = new ValueArgument<string>('t', "logtype", "Type of log you would like to output. Currently supported options are plain and JSON. Defaults to plain.");
             ValueArgument<string> timeOutArg = new ValueArgument<string>('e', "timeout",
                 "Interval between status updates (in minutes) also acts as a timeout for AD data to be gathered via LDAP. Turn this knob up if you aren't getting any computers from AD when you run Snaffler through a proxy or other slow link. Default = 5");
-            // list of letters i haven't used yet: gnqw
+            // list of letters i haven't used yet: gnw
 
             CommandLineParser.CommandLineParser parser = new CommandLineParser.CommandLineParser();
             parser.Arguments.Add(timeOutArg);
@@ -132,6 +133,7 @@ namespace Snaffler
             parser.Arguments.Add(ruleDirArg);
             parser.Arguments.Add(logType);
             parser.Arguments.Add(compExclusionArg);
+            parser.Arguments.Add(cidrTargetArg);
 
             // extra check to handle builtin behaviour from cmd line arg parser
             if ((args.Contains("--help") || args.Contains("/?") || args.Contains("help") || args.Contains("-h") || args.Length == 0))
@@ -256,6 +258,19 @@ namespace Snaffler
                     else
                     {
                         throw new Exception("Failed to get a valid list of excluded computers from the excluded computers list.");
+                    }
+                }
+
+                if (cidrTargetArg.Parsed)
+                {
+                    parsedConfig.CidrInclusions = cidrTargetArg.Value.Split(',')
+                        .Select(l => l.Trim())
+                        .Where(l => SnaffCore.NetworkUtils.CidrRegex.IsMatch(l))
+                        .ToList();
+
+                    if (parsedConfig.CidrInclusions.Count == 0)
+                    {
+                        throw new Exception("No valid CIDRs found in -q argument. Expected format: 10.1.2.0/24");
                     }
                 }
 

--- a/Snaffler/Config.cs
+++ b/Snaffler/Config.cs
@@ -254,6 +254,10 @@ namespace Snaffler
                     if (compExclusions.Count > 0)
                     {
                         parsedConfig.ComputerExclusions = compExclusions;
+                        var cidrs = compExclusions.Where(e => SnaffCore.NetworkUtils.CidrRegex.IsMatch(e)).ToList();
+                        var ips = compExclusions.Where(e => !SnaffCore.NetworkUtils.CidrRegex.IsMatch(e)).ToList();
+                        if (cidrs.Count > 0) Mq.Info("CIDR exclusions active: " + string.Join(", ", cidrs));
+                        if (ips.Count > 0) Mq.Info("Excluding " + ips.Count + " host(s) by IP.");
                     }
                     else
                     {
@@ -272,6 +276,8 @@ namespace Snaffler
                     {
                         throw new Exception("No valid CIDRs found in -q argument. Expected format: 10.1.2.0/24");
                     }
+
+                    Mq.Info("CIDR target filter active: " + string.Join(", ", parsedConfig.CidrInclusions));
                 }
 
                 if (compTargetArg.Parsed)

--- a/Tests/CidrTest.cs
+++ b/Tests/CidrTest.cs
@@ -1,0 +1,87 @@
+// Test harness for CIDR exclusion logic in SnaffCore.NetworkUtils.
+// Compile: csc /reference:SnaffCore.dll Tests\CidrTest.cs
+// Run:     CidrTest.exe
+using System;
+using System.Net;
+using SnaffCore;
+
+class CidrTest
+{
+    static int passed = 0;
+    static int failed = 0;
+
+    static void Main()
+    {
+        // --- IPv4 standard cases ---
+        Test("10.1.2.100",   "10.1.2.0/24",    true,  "IPv4 host inside /24");
+        Test("10.1.3.1",     "10.1.2.0/24",    false, "IPv4 host outside /24");
+        Test("10.5.6.7",     "10.0.0.0/8",     true,  "IPv4 host inside /8");
+        Test("11.0.0.1",     "10.0.0.0/8",     false, "IPv4 host outside /8");
+        Test("172.16.5.5",   "172.16.0.0/16",  true,  "IPv4 host inside /16");
+        Test("172.17.0.1",   "172.16.0.0/16",  false, "IPv4 host outside /16");
+
+        // --- Boundary cases ---
+        Test("10.1.2.0",     "10.1.2.0/24",    true,  "Network address itself");
+        Test("10.1.2.255",   "10.1.2.0/24",    true,  "Broadcast address");
+        Test("10.1.3.0",     "10.1.2.0/24",    false, "First address of next network");
+
+        // --- Non-byte-boundary prefix (/20, /25 etc.) ---
+        Test("10.1.16.1",    "10.1.16.0/20",   true,  "IPv4 host inside /20");
+        Test("10.1.32.1",    "10.1.16.0/20",   false, "IPv4 host outside /20");
+        Test("192.168.1.1",  "192.168.1.0/25", true,  "IPv4 host inside /25 lower half");
+        Test("192.168.1.128","192.168.1.0/25", false, "IPv4 host in upper half of /25");
+
+        // --- /32 single host ---
+        Test("192.168.1.1",  "192.168.1.1/32", true,  "/32 exact match");
+        Test("192.168.1.2",  "192.168.1.1/32", false, "/32 non-match");
+
+        // --- /0 match everything ---
+        Test("1.2.3.4",      "0.0.0.0/0",      true,  "IPv4 /0 matches any address");
+        Test("255.255.255.255","0.0.0.0/0",     true,  "IPv4 /0 matches broadcast");
+
+        // --- IPv6 ---
+        Test("2001:db8::1",  "2001:db8::/32",  true,  "IPv6 host inside /32");
+        Test("2001:db9::1",  "2001:db8::/32",  false, "IPv6 host outside /32");
+        Test("fe80::1",      "fe80::/10",       true,  "IPv6 link-local inside /10");
+        Test("fe40::1",      "fe80::/10",       false, "IPv6 outside link-local /10");
+
+        // --- Mixed family (should never match) ---
+        Test("10.1.2.1",     "2001:db8::/32",  false, "IPv4 address vs IPv6 CIDR");
+        Test("2001:db8::1",  "10.1.2.0/24",    false, "IPv6 address vs IPv4 CIDR");
+
+        // --- Malformed input (should not throw, just return false) ---
+        TestMalformed("notacidr",         "Malformed: no slash");
+        TestMalformed("10.1.2.0/abc",     "Malformed: non-numeric prefix");
+        TestMalformed("999.999.999.999/24","Malformed: invalid network address");
+        TestMalformed("/24",              "Malformed: missing network address");
+
+        Console.WriteLine();
+        Console.WriteLine($"Results: {passed} passed, {failed} failed");
+        Environment.Exit(failed > 0 ? 1 : 0);
+    }
+
+    static void Test(string ip, string cidr, bool expected, string label)
+    {
+        IPAddress address = IPAddress.Parse(ip);
+        bool result = NetworkUtils.IsInCidr(address, cidr);
+        bool ok = result == expected;
+        if (ok) passed++; else failed++;
+        Console.WriteLine($"[{(ok ? "PASS" : "FAIL")}] {label}: {ip} in {cidr} => {result} (expected {expected})");
+    }
+
+    static void TestMalformed(string cidr, string label)
+    {
+        try
+        {
+            bool result = NetworkUtils.IsInCidr(IPAddress.Parse("10.1.2.1"), cidr);
+            bool ok = result == false;
+            if (ok) passed++; else failed++;
+            Console.WriteLine($"[{(ok ? "PASS" : "FAIL")}] {label}: returned {result} (expected false)");
+        }
+        catch (Exception ex)
+        {
+            failed++;
+            Console.WriteLine($"[FAIL] {label}: threw exception: {ex.Message}");
+        }
+    }
+}


### PR DESCRIPTION
I've implemented functionality to allow Snaffler to either include or exclude targets based on specified CIDRs.

The `-k` argument has been extended to support excluding CIDRs, and follows similar logic to how `-n` allows a target file or comma-separated list. This flag was undocumented before, so I added it to the `README.md` file

A new `-q` argument has been implemented, to allow specifying "in-scope" CIDRs. This follows similar patterns to `-k`