### PR TITLE
Detect passwords in CMD set statements

### DIFF
--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Code/Cmd/KeepCmdCredentials.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Code/Cmd/KeepCmdCredentials.toml
@@ -7,7 +7,7 @@ MatchLocation = "FileContentAsString"
 WordListType = "Regex"
 MatchLength = 0
 WordList = ["passwo?r?d\\s*=\\s*[\\'\\\"][^\\'\\\"]....",
-"set\\s*\\"?\\w*passwo?r?d=....",
+"set\\s*\\\"?\\w*passwo?r?d=....",
 "schtasks.{1,300}(/rp\\s|/p\\s)",
 "net user ",
 "psexec .{0,100} -p ",

--- a/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Code/Cmd/KeepCmdCredentials.toml
+++ b/Snaffler/SnaffRules/DefaultRules/FileRules/Keep/Code/Cmd/KeepCmdCredentials.toml
@@ -7,6 +7,7 @@ MatchLocation = "FileContentAsString"
 WordListType = "Regex"
 MatchLength = 0
 WordList = ["passwo?r?d\\s*=\\s*[\\'\\\"][^\\'\\\"]....",
+"set\\s*\\"?\\w*passwo?r?d=....",
 "schtasks.{1,300}(/rp\\s|/p\\s)",
 "net user ",
 "psexec .{0,100} -p ",


### PR DESCRIPTION
## Overview

Update `KeepCmdCredentials` to detect passwords assigned through CMD `set` statements.

Examples:
- `set PASSWORD=...`
- `set PGPASSWORD=...`
- `set "PASSWORD=..."`

## Why

Some CMD and batch files store credentials in environment variables using `set` statements.

This change improves detection for those password assignment patterns.